### PR TITLE
fix(cue): gate only when the deck was paused at the press

### DIFF
--- a/docs/hot-cues.md
+++ b/docs/hot-cues.md
@@ -5,16 +5,19 @@ of them off the pads behave exactly as they always did.
 
 ## GATE CUE
 
-Ships **OFF**. Makes the pads momentary.
+Ships **OFF**. Makes the pads momentary while the deck is paused.
 
 | | |
 | --- | --- |
-| Press a pad | Jumps to the cue and plays, as normal |
+| Press a pad **while paused** | Jumps to the cue and plays for as long as you hold it |
 | **Release the pad** | Returns to the cue and pauses |
 | Press **PLAY** while still holding | Latches, and the track keeps playing when you let go |
+| Press a pad **while playing** | A normal hot cue: jumps to the cue and keeps playing |
 
 So a short stab is a stab, and a press you decide to keep is a press you keep,
-without having to decide before you press.
+without having to decide before you press. Whether a press gates is decided
+when you press it, from whether the deck was playing at that moment; a second
+pad pressed during a hold joins the first.
 
 ![GATE CUE on: holding a pad plays from the cue, and releasing it returns there and pauses.](vid/gate-cue.mp4)
 

--- a/docs/hot-cues.md
+++ b/docs/hot-cues.md
@@ -16,7 +16,7 @@ Ships **OFF**. Makes the pads momentary while the deck is paused.
 
 So a short stab is a stab, and a press you decide to keep is a press you keep,
 without having to decide before you press. Whether a press gates is decided
-when you press it, from whether the deck was playing at that moment; a second
+when you press it, from whether the deck was paused at that moment; a second
 pad pressed during a hold joins the first.
 
 ![GATE CUE on: holding a pad plays from the cue, and releasing it returns there and pauses.](vid/gate-cue.mp4)

--- a/package/deck/mods/cue/cue.h
+++ b/package/deck/mods/cue/cue.h
@@ -154,9 +154,10 @@ void *cue_controller(const struct cue_event *ev);      /* [deck] */
 /* How many hot-cue pads are down right now. */
 int cue_pads_held(void);                               /* [deck] */
 
-/* Was the deck playing when this event's press arrived? Read off the pad
- * handler's own dj_player::PlayerState. 0 when it cannot be read. [deck] */
-int cue_deck_playing(const struct cue_event *ev);
+/* Was the deck paused at this event's press, as the deck itself defines paused
+ * (a track loaded, not playing, not in a cue mode)? Read off the pad handler's
+ * own dj_player::PlayerState; 0 when it cannot be read or is not one. */
+int cue_deck_paused(const struct cue_event *ev);                /* [deck] */
 
 /* CueController slots. Each is one thin forwarder to a dj_player::ICueLoopSetter
  * method -- see docs/mods.md and the memory note for the whole map.

--- a/package/deck/mods/cue/cue.h
+++ b/package/deck/mods/cue/cue.h
@@ -154,6 +154,10 @@ void *cue_controller(const struct cue_event *ev);      /* [deck] */
 /* How many hot-cue pads are down right now. */
 int cue_pads_held(void);                               /* [deck] */
 
+/* Was the deck playing when this event's press arrived? Read off the pad
+ * handler's own dj_player::PlayerState. 0 when it cannot be read. [deck] */
+int cue_deck_playing(const struct cue_event *ev);
+
 /* CueController slots. Each is one thin forwarder to a dj_player::ICueLoopSetter
  * method -- see docs/mods.md and the memory note for the whole map.
  *

--- a/package/deck/mods/cue/gate.c
+++ b/package/deck/mods/cue/gate.c
@@ -79,15 +79,14 @@ static void gate_pad(const struct cue_event *ev, enum cue_phase phase)
         /* First pad of a session decides it; a second pad joins the one
          * already running rather than starting a new one. */
         if (cue_pads_held() == 1) {
-            int playing = cue_deck_playing(ev);
+            int armed = g_gate_on && cue_deck_paused(ev);
 
             __atomic_store_n(&gate_g_latched, 0, __ATOMIC_RELAXED);
-            __atomic_store_n(&gate_g_armed, g_gate_on && !playing,
-                             __ATOMIC_RELAXED);
+            /* RELEASE: PLAY's task may already be running with held == 1. */
+            __atomic_store_n(&gate_g_armed, armed, __ATOMIC_RELEASE);
             if (g_gate_on)
-                MDBG("gate: pad %d down with the deck %s -> %s\n", ev->pad,
-                     playing ? "playing" : "paused",
-                     playing ? "the deck's own hot cue" : "gated");
+                MDBG("gate: pad %d down -> %s\n", ev->pad,
+                     armed ? "gated" : "the deck's own hot cue");
         }
         break;
 

--- a/package/deck/mods/cue/gate.c
+++ b/package/deck/mods/cue/gate.c
@@ -2,9 +2,14 @@
 /*
  * cue/gate.c - GATE CUE: momentary / play-while-press hot cues.
  *
+ * With the deck PAUSED:
  *   - press a hot-cue pad   -> jump to that cue and PLAY while held (stock)
  *   - release the pad       -> return to the cue point and PAUSE (back-cue)
  *   - press PLAY while held -> LATCH; releasing then no longer back-cues
+ *
+ * With the deck PLAYING the pads are the deck's own: a press jumps and keeps
+ * playing, the release does nothing, and PLAY is PLAY. Decided once per
+ * session, on its first pad, from the deck's play state at that moment.
  *
  * Nothing here performs the back-cue: it asks the deck's own release for one by
  * naming an op, and the deck's release task does it. Everything in this file is
@@ -29,8 +34,13 @@
 
 int g_gate_on;                  /* persisted; see mods/common.c */
 
-/* One momentary session. A PLAY press during the hold promoted it to continuous
- * playback, so the release must not back-cue. */
+/* One momentary session: from the first pad down to the last pad up. Armed
+ * when it began with the deck paused; a second pad joins whichever session is
+ * running rather than deciding again. */
+static int gate_g_armed;
+
+/* A PLAY press during the hold promoted it to continuous playback, so the
+ * release must not back-cue. */
 static int gate_g_latched;
 
 /* Pads whose press did anything OTHER than go to a cue that was already there,
@@ -66,10 +76,19 @@ static void gate_pad(const struct cue_event *ev, enum cue_phase phase)
             gate_g_had |= 1u << ev->pad;
         else
             gate_g_had &= ~(1u << ev->pad);
-        /* First pad of a session clears the latch; a second pad joins the one
+        /* First pad of a session decides it; a second pad joins the one
          * already running rather than starting a new one. */
-        if (g_gate_on && cue_pads_held() == 1)
+        if (cue_pads_held() == 1) {
+            int playing = cue_deck_playing(ev);
+
             __atomic_store_n(&gate_g_latched, 0, __ATOMIC_RELAXED);
+            __atomic_store_n(&gate_g_armed, g_gate_on && !playing,
+                             __ATOMIC_RELAXED);
+            if (g_gate_on)
+                MDBG("gate: pad %d down with the deck %s -> %s\n", ev->pad,
+                     playing ? "playing" : "paused",
+                     playing ? "the deck's own hot cue" : "gated");
+        }
         break;
 
     case CUE_PAD_PRESSED:
@@ -80,8 +99,10 @@ static void gate_pad(const struct cue_event *ev, enum cue_phase phase)
         break;
 
     case CUE_PAD_UP:
-        if (g_gate_on && cue_pads_held() == 0)
+        if (cue_pads_held() == 0) {
             __atomic_store_n(&gate_g_latched, 0, __ATOMIC_RELAXED);
+            __atomic_store_n(&gate_g_armed, 0, __ATOMIC_RELAXED);
+        }
         break;
     }
 }
@@ -89,7 +110,7 @@ static void gate_pad(const struct cue_event *ev, enum cue_phase phase)
 /* Whether the deck's own release should come back to the cue. */
 static int gate_release_op(const struct cue_event *ev)
 {
-    if (!g_gate_on)
+    if (!g_gate_on || !__atomic_load_n(&gate_g_armed, __ATOMIC_ACQUIRE))
         return 0;
     if (__atomic_load_n(&gate_g_latched, __ATOMIC_ACQUIRE)) {
         MDBG("gate: latched -> keep playing\n");
@@ -123,7 +144,8 @@ static int gate_release_op(const struct cue_event *ev)
 /* Claim the PLAY press: it means "keep going", not play/pause. */
 static int gate_play_while_held(void)
 {
-    if (!g_gate_on || __atomic_load_n(&gate_g_latched, __ATOMIC_ACQUIRE))
+    if (!g_gate_on || !__atomic_load_n(&gate_g_armed, __ATOMIC_ACQUIRE) ||
+        __atomic_load_n(&gate_g_latched, __ATOMIC_ACQUIRE))
         return 0;
     __atomic_store_n(&gate_g_latched, 1, __ATOMIC_RELAXED);
     MDBG("gate: PLAY during hold -> latched\n");

--- a/package/deck/mods/cue/pad.c
+++ b/package/deck/mods/cue/pad.c
@@ -30,9 +30,13 @@
  * knows the zone is held without going anywhere near the strip's own drawing.
  *
  * Every input handler embeds a dj_player::PlayerState at +0x80, the deck's own
- * snapshot of the player. Its flag bytes at +0x65..+0x67 read as one state --
- * sub_11459f0: +0x65 -> 0, else +0x67 ? 2 : 1, +0x66 -> 3 -- and +0x67 is the
- * one that says PLAYING. Read at the press, off the handler the closure names.
+ * snapshot of the player. The deck's input-state snapshot (sub_138f5e8) derives
+ * its PAUSED bit from it as: load state +0x20 == 2, and sub_11459f0 == 1, where
+ * sub_11459f0 is
+ *     +0x65 ? 0 : (+0x66 && !+0x6b) ? 3 : +0x67 ? 2 : 1
+ * 2 is playing, 1 paused; 0 and 3 are modes the PLAY button and the load lock
+ * treat as not paused. cue_deck_paused evaluates the same expression, read at
+ * the press off the handler the closure names.
  */
 #include "cue/cue.h"
 #include "kit/mod.h"
@@ -45,9 +49,13 @@
 #define PREVIEW_SET_SLOT   0x10   /* PreviewController: the touched point   */
 #define PREVIEW_CLEAR_SLOT 0x18   /* ...and letting go                      */
 
-/* dj_player::PlayerState inside every input handler, and its play byte. */
+/* dj_player::PlayerState inside every input handler, and the bytes the deck's
+ * own paused predicate reads. */
 #define HANDLER_STATE_OFF  0x80
-#define STATE_PLAYING_OFF  0x67
+#define STATE_LOAD_OFF     0x20   /* int32; 2 = a track is loaded            */
+#define STATE_LOADED       2
+#define STATE_FLAGS_OFF    0x65   /* +0x65 +0x66 +0x67, and +0x6b, one byte each */
+#define STATE_FLAGS_LEN    7
 
 #define FN_LINK_DECK       ep122_sym(EP122_CUE_LINK_DECK)
 #define FN_LINK_FACADE     ep122_sym(EP122_CUE_LINK_FACADE)
@@ -116,17 +124,32 @@ static float cue_g_needle_at;
 int cue_pad_ready(void) { return cue_g_ready; }
 int cue_pads_held(void) { return __atomic_load_n(&cue_g_held, __ATOMIC_ACQUIRE); }
 
-int cue_deck_playing(const struct cue_event *ev)
+int cue_deck_paused(const struct cue_event *ev)
 {
-    uintptr_t handler = 0;
-    uint8_t   st[4];
+    static int broken;
+    uintptr_t handler = 0, state;
+    int32_t   load = 0;
+    uint8_t   f[STATE_FLAGS_LEN];   /* f[0..2] = +0x65..+0x67, f[6] = +0x6b */
 
-    if (mod_safe_read((uintptr_t)ev->task + CLOSURE_HANDLER_OFF, &handler, sizeof(handler)) != 0 ||
-        !handler ||
-        mod_safe_read(handler + HANDLER_STATE_OFF + 0x64, st, sizeof(st)) != 0)
+    if (broken)
         return 0;
-    MDBG("cue: player state %02x %02x %02x %02x\n", st[0], st[1], st[2], st[3]);
-    return st[STATE_PLAYING_OFF - 0x64] != 0;
+    if (mod_safe_read((uintptr_t)ev->task + CLOSURE_HANDLER_OFF, &handler, sizeof(handler)) != 0 ||
+        !handler)
+        return 0;
+    state = handler + HANDLER_STATE_OFF;
+    if (mod_safe_read(state + STATE_LOAD_OFF, &load, sizeof(load)) != 0 ||
+        mod_safe_read(state + STATE_FLAGS_OFF, f, sizeof(f)) != 0)
+        return 0;
+    /* The flags are bools. Anything else is not the layout this reads, and a
+     * misread must not gate: it would give every press the paused answer. */
+    if (f[0] > 1 || f[1] > 1 || f[2] > 1 || f[6] > 1) {
+        MERR("cue: handler+%#x is not a PlayerState (flags %02x %02x %02x .. %02x)"
+             " -> pads never gate\n", HANDLER_STATE_OFF, f[0], f[1], f[2], f[6]);
+        broken = 1;
+        return 0;
+    }
+    MDBG("cue: player load %d flags %02x %02x %02x .. %02x\n", load, f[0], f[1], f[2], f[6]);
+    return load == STATE_LOADED && !f[0] && !(f[1] && !f[6]) && !f[2];
 }
 
 /* ================================================================== */

--- a/package/deck/mods/cue/pad.c
+++ b/package/deck/mods/cue/pad.c
@@ -28,6 +28,11 @@
  * the strip's touch drives: slot +0x10 carries the touched point as a
  * normalised fraction and +0x18 clears it. Hooking the pair is how the layer
  * knows the zone is held without going anywhere near the strip's own drawing.
+ *
+ * Every input handler embeds a dj_player::PlayerState at +0x80, the deck's own
+ * snapshot of the player. Its flag bytes at +0x65..+0x67 read as one state --
+ * sub_11459f0: +0x65 -> 0, else +0x67 ? 2 : 1, +0x66 -> 3 -- and +0x67 is the
+ * one that says PLAYING. Read at the press, off the handler the closure names.
  */
 #include "cue/cue.h"
 #include "kit/mod.h"
@@ -39,6 +44,10 @@
 #define CUE_RUN_SLOT       0x10   /* AsyncTask::run, on every closure class */
 #define PREVIEW_SET_SLOT   0x10   /* PreviewController: the touched point   */
 #define PREVIEW_CLEAR_SLOT 0x18   /* ...and letting go                      */
+
+/* dj_player::PlayerState inside every input handler, and its play byte. */
+#define HANDLER_STATE_OFF  0x80
+#define STATE_PLAYING_OFF  0x67
 
 #define FN_LINK_DECK       ep122_sym(EP122_CUE_LINK_DECK)
 #define FN_LINK_FACADE     ep122_sym(EP122_CUE_LINK_FACADE)
@@ -106,6 +115,19 @@ static float cue_g_needle_at;
 
 int cue_pad_ready(void) { return cue_g_ready; }
 int cue_pads_held(void) { return __atomic_load_n(&cue_g_held, __ATOMIC_ACQUIRE); }
+
+int cue_deck_playing(const struct cue_event *ev)
+{
+    uintptr_t handler = 0;
+    uint8_t   st[4];
+
+    if (mod_safe_read((uintptr_t)ev->task + CLOSURE_HANDLER_OFF, &handler, sizeof(handler)) != 0 ||
+        !handler ||
+        mod_safe_read(handler + HANDLER_STATE_OFF + 0x64, st, sizeof(st)) != 0)
+        return 0;
+    MDBG("cue: player state %02x %02x %02x %02x\n", st[0], st[1], st[2], st[3]);
+    return st[STATE_PLAYING_OFF - 0x64] != 0;
+}
 
 /* ================================================================== */
 /* Decoding an event                                                  */


### PR DESCRIPTION
Closes #2

A hot cue pressed while the deck is playing is a normal hot cue again; a pad only gates (plays while held, returns on release) when the deck was paused at the press. The play state is read off the pad handler's PlayerState, the same byte overcue reads.