### PR TITLE
fix(browse): gate EDIT on the playlist's list cache

### DIFF
--- a/docs/browsing.md
+++ b/docs/browsing.md
@@ -22,4 +22,7 @@ exactly as it always did.
 
 ## Playlists only
 
-The EDIT button appears only on playlists views
+A playlist's `#` is a stored position that belongs to that list, so moving a
+track in it changes that list. An album's or an artist's `#` is the track's
+own number out of its tags, and there is nothing a reorder could mean there.
+The EDIT button therefore appears only on playlist views.

--- a/docs/browsing.md
+++ b/docs/browsing.md
@@ -9,7 +9,7 @@ The browse screen uses single-finger dragging to scroll through lists. To enable
 
 ## Reordering a playlist
 
-1. Open a **playlist**.
+1. Open a **playlist** (via **BROWSE** or **PLAYLIST** button).
 2. Tap **EDIT** in the browse header.
 3. **Drag a track** to where you want it.
 4. Tap **EDIT** again when you are done.
@@ -22,10 +22,4 @@ exactly as it always did.
 
 ## Playlists only
 
-A playlist's `#` is a stored position that belongs to that list, so moving a
-track in it changes that list.
-
-> **Known limitation.** EDIT currently appears on **any** track list, not only
-> on playlists. Dragging somewhere it cannot be saved is refused at the point
-> of writing, so nothing is corrupted. The move simply does not stick. The
-> work to hide the toggle where it does not apply is not finished.
+The EDIT button appears only on playlists views

--- a/package/deck/mods/browse/browse.h
+++ b/package/deck/mods/browse/browse.h
@@ -29,26 +29,18 @@
  *
  * ---- and this is how it knows -----------------------------------------------
  *
- * THE LEFT SIDEBAR. It tracks the LEVEL, not the tab that was pressed: reaching
- * an album through ARTIST -> an artist -> an album leaves it highlighting ALBUM,
- * and a playlist leaves it on PLAYLIST. The deck is already drawing the answer;
- * the selected row of that list is it. See SIDE_SELROW_OFF below.
+ * THE LIST CACHE IT IS SERVED FROM. Every cached list keeps the condition it
+ * was asked for, a playlist's carries a playlist hierarchy, and the cache on
+ * screen is the one held by someone other than the collector.
+ * mod_djdb_playlist_shown is that walk, shared with the reorder's write.
  *
- * Two things had to be eliminated first, and both were eliminated by MEASURING
- * rather than by reasoning, because reasoning got the first one wrong twice:
+ * Under gui::PlayListView -- the PLAYLIST button's screen -- a track list is a
+ * playlist by construction.
  *
- *   - djdb cannot answer. The deck warms a list cache when the media is
- *     announced and browses out of it, so the playlist cursor runs once per
- *     MEDIA, not once per list. A whole session of navigating: two queries, both
- *     of them ours.
- *   - neither widget carries it. gui::TrackListWidget is byte-identical in its
- *     first 0x100 for a playlist and for an album -- one object serves both --
- *     and gui::BrowseTitleWidget holds only its title string and the icon
- *     BITMAP, at pointers into an image arena that differ between two visits to
- *     the same playlist. (The first attempt at that one read FORWARD from the
- *     juce::Component subobject, which for a virtual base is the wrong end of
- *     the object entirely, and concluded from 640 bytes of nothing that the
- *     header was empty. Walk back through offset-to-top at vptr[-2].)
+ * Nothing else answers. The browse sidebar's categories come off the stick
+ * (djdbMenuItems), so neither its row count nor PLAYLIST's index is a constant.
+ * gui::TrackListWidget serves a playlist and an album from one object, and
+ * gui::BrowseTitleWidget holds only a title and an icon bitmap.
  *
  * And the `#` column is a second, independent condition rather than a
  * replacement: it keeps EDIT off the split preview pane, where a playlist is
@@ -245,25 +237,9 @@ int browse_drag_install(void);
  * them at full strength and only dimmed the lettering. */
 #define DG_GHOST_ALPHA  0.55f
 
-/* ---- the category, which the deck draws in the sidebar -------------------
- *
- * THE LEFT SIDEBAR TRACKS THE LEVEL, NOT THE TAB THAT WAS PRESSED. Reaching an
- * album through ARTIST -> an artist -> an album leaves it highlighting ALBUM;
- * a playlist leaves it on PLAYLIST. So the deck is already showing what kind of
- * list is on screen, and its selected row IS that answer -- measured live, the
- * row moved 0 -> 4 walking into a playlist and 0 -> 1 walking into an album.
- *
- * The box is the one meow::TouchableTableListBox whose viewport is 90 wide.
- * Selected row at +0x108, row count at +0xf8.
- *
- * The ORDER is the deck's fixed browse-category list, and the count is checked
- * before the index is believed: a medium that offers a different set of
- * categories fails this CLOSED -- no EDIT -- rather than reordering whatever
- * happens to sit at index 4. */
-#define SIDE_NROWS_OFF   0xf8
-#define SIDE_SELROW_OFF  0x108
-#define SIDE_NROWS       9      /* ARTIST ALBUM TRACK KEY PLAYLIST HISTORY ... */
-#define SIDE_PLAYLIST    4
+/* Display ticks between polls of the list caches: a few dozen /proc/self/mem
+ * reads, not for 44 Hz. 11 ticks is 250 ms, inside the list's own transition. */
+#define BE_GATE_TICKS  11
 
 /* Row geometry and identity, read out of RowComp::paint (0x190f6a0), which
  * hands all three to the model:

--- a/package/deck/mods/browse/browse.h
+++ b/package/deck/mods/browse/browse.h
@@ -30,9 +30,11 @@
  * ---- and this is how it knows -----------------------------------------------
  *
  * THE LIST CACHE IT IS SERVED FROM. Every cached list keeps the condition it
- * was asked for, a playlist's carries a playlist hierarchy, and the cache on
- * screen is the one held by someone other than the collector.
- * mod_djdb_playlist_shown is that walk, shared with the reorder's write.
+ * was asked for, a playlist's carries a playlist hierarchy, and the list on
+ * screen is served from the newest cache held by someone other than the
+ * collector. mod_djdb_playlist_shown answers from that cache and is asked
+ * again the moment the list on screen changes; the reorder's write asks the
+ * same scan through mod_djdb_playlist_now.
  *
  * Under gui::PlayListView -- the PLAYLIST button's screen -- a track list is a
  * playlist by construction.
@@ -192,6 +194,8 @@ int browse_sort_hold(void);
  * offered where there are tracks, and the gesture only runs on the list the
  * mode was entered on. [message] */
 uintptr_t browse_track_list(uintptr_t bar);
+/* The first VISIBLE component of the class at vtable `vt` under `comp`. */
+uintptr_t bs_find_visible_class(uintptr_t comp, uintptr_t vt);
 
 /* End a drag that stopped arriving. [message] */
 void browse_drag_tick(void);

--- a/package/deck/mods/browse/edit.c
+++ b/package/deck/mods/browse/edit.c
@@ -90,22 +90,50 @@ static int be_under_playlist_view(uintptr_t list)
     return 0;
 }
 
-/* The browse screen's answer, polled every BE_GATE_TICKS. */
-static uint32_t be_shown_playlist(void)
+/* The model's row count, through the slot the deck reads it from: the list's
+ * visible row's owner is the box, and the box holds the model. */
+static int be_num_rows(uintptr_t list)
 {
-    static uint32_t pid;
-    static int      ticks;
+    uintptr_t rc = bs_find_visible_class(list, ep122_sym(EP122_ROWCOMP));
+    uintptr_t owner = 0, model = 0, vt = 0, fn = 0;
 
+    if (!rc || mod_safe_read(rc + RC_OWNER_OFF, &owner, sizeof(owner)) != 0 || !owner)
+        return -1;
+    if (mod_safe_read(owner + LB_MODEL_OFF, &model, sizeof(model)) != 0 || !model)
+        return -1;
+    if (mod_safe_read(model, &vt, sizeof(vt)) != 0 || !vt)
+        return -1;
+    if (mod_safe_read(vt + MODEL_NUMROWS, &fn, sizeof(fn)) != 0 || !fn)
+        return -1;
+    return (int)((int64_t (*)(void *))fn)((void *)model);
+}
+
+/* The browse screen's answer: the collector's newest held track-list cache,
+ * asked every BE_GATE_TICKS, and at once when the list on screen changes --
+ * the widget is reused between an album and a playlist, so the row count is
+ * the change that shows. Kept in be_g_pid so the log can quote it. */
+static uint32_t be_g_pid;
+
+static void be_poll_playlist(uintptr_t list)
+{
+    static uintptr_t last_list;
+    static int       last_rows, ticks;
+    int rows = list ? be_num_rows(list) : -1;
+
+    if (list != last_list || rows != last_rows) {
+        last_list = list;
+        last_rows = rows;
+        ticks = 0;
+    }
     if (ticks-- <= 0) {
         ticks = BE_GATE_TICKS - 1;
-        pid = mod_djdb_playlist_shown();
+        be_g_pid = mod_djdb_playlist_shown();
     }
-    return pid;
 }
 
 static int be_on_playlist(uintptr_t list)
 {
-    return be_under_playlist_view(list) || be_shown_playlist() != 0;
+    return be_under_playlist_view(list) || be_g_pid != 0;
 }
 
 /* ---- the mark -------------------------------------------------------------
@@ -430,12 +458,12 @@ static void be_sync(void)
      * reorder could mean. The deck clears the column's flags on those, so this
      * is one bit rather than a guess about which view is up. */
     list = browse_track_list(be_g_bar);
+    be_poll_playlist(list);
     want = list != 0 && browse_sort_has_position(be_g_bar) && be_on_playlist(list);
     if (want == be_g_shown)
         return;
     MDBG("browse: EDIT %s -- list %p, playlist %u%s\n",
-         want ? "shown" : "hidden", (void *)list,
-         (unsigned)be_shown_playlist(),
+         want ? "shown" : "hidden", (void *)list, (unsigned)be_g_pid,
          list && be_under_playlist_view(list) ? " (PLAYLIST screen)" : "");
     be_g_shown = want;
     juce_comp_set_visible(be_g_btn, want);

--- a/package/deck/mods/browse/edit.c
+++ b/package/deck/mods/browse/edit.c
@@ -75,39 +75,8 @@ static void be_repaint(uintptr_t comp)
 
 /* ---- is the list on screen a PLAYLIST? ------------------------------------
  *
- * See browse.h for why the sidebar answers this and nothing else does. Found by
- * shape rather than by class name: the browse sidebar is the one
- * meow::TouchableViewport::ViewedComponent 90 wide, and its box is three up --
- * ViewedComponent, a plain juce::Component, ListViewport, then the box. */
-static uintptr_t be_side_box(uintptr_t comp, int depth)
-{
-    int32_t b[4];
-    int n, i;
-
-    if (!comp || depth > 8 || !juce_comp_visible(comp))
-        return 0;
-    if (juce_comp_class(comp) == juce_class_of(ep122_sym(EP122_VIEWED_COMP)) &&
-        juce_comp_bounds(comp, b) == 0 && b[2] == 90) {
-        uintptr_t c = comp;
-
-        for (i = 0; i < 3 && c; i++)
-            c = juce_comp_parent(c);
-        return c;
-    }
-    n = juce_comp_nchild(comp);
-    for (i = 0; i < n; i++) {
-        uintptr_t hit = be_side_box(juce_comp_child(comp, i), depth + 1);
-
-        if (hit)
-            return hit;
-    }
-    return 0;
-}
-
-/* Under gui::PlayListView -- the screen behind the deck's own PLAYLIST button.
- * That screen shows playlists and nothing else, so a track list inside one IS a
- * playlist and no other evidence is needed. It also has no sidebar, which is why
- * the sidebar alone left EDIT off the one screen a DJ reaches with a button. */
+ * See browse.h. Under gui::PlayListView -- the PLAYLIST button's screen -- a
+ * track list is a playlist by construction. */
 static int be_under_playlist_view(uintptr_t list)
 {
     uintptr_t ti = juce_class_of(ep122_sym(EP122_PLAYLIST_VIEW)), c = list;
@@ -121,20 +90,22 @@ static int be_under_playlist_view(uintptr_t list)
     return 0;
 }
 
+/* The browse screen's answer, polled every BE_GATE_TICKS. */
+static uint32_t be_shown_playlist(void)
+{
+    static uint32_t pid;
+    static int      ticks;
+
+    if (ticks-- <= 0) {
+        ticks = BE_GATE_TICKS - 1;
+        pid = mod_djdb_playlist_shown();
+    }
+    return pid;
+}
+
 static int be_on_playlist(uintptr_t list)
 {
-    uintptr_t box;
-    int32_t rows = 0, sel = -1;
-
-    if (be_under_playlist_view(list))
-        return 1;
-    box = be_side_box(juce_comp_root(be_g_bar), 0);
-    if (!box)
-        return 0;
-    if (mod_safe_read(box + SIDE_NROWS_OFF, &rows, sizeof(rows)) != 0 ||
-        mod_safe_read(box + SIDE_SELROW_OFF, &sel, sizeof(sel)) != 0)
-        return 0;
-    return rows == SIDE_NROWS && sel == SIDE_PLAYLIST;
+    return be_under_playlist_view(list) || be_shown_playlist() != 0;
 }
 
 /* ---- the mark -------------------------------------------------------------
@@ -424,8 +395,8 @@ static void be_attach(uintptr_t bar)
  *
  * The second half is the PLAYLIST-ONLY gate. An artist's or album's `#` is the
  * track's own album number out of its tags, so a reorder there would rewrite
- * metadata rather than move anything; mod_djdb_playlist_now is 0 unless the
- * list on screen came from the playlist table.
+ * metadata rather than move anything; be_on_playlist is 0 unless the list on
+ * screen is served from a playlist's cache or sits on the PLAYLIST screen.
  *
  * Turning the mode OFF on the way out, not just hiding the plate: coming back to
  * a browse screen with an invisible EDIT still latched would leave the list in a
@@ -462,9 +433,10 @@ static void be_sync(void)
     want = list != 0 && browse_sort_has_position(be_g_bar) && be_on_playlist(list);
     if (want == be_g_shown)
         return;
-    MDBG("browse: EDIT %s -- list %p, playlist %u\n",
+    MDBG("browse: EDIT %s -- list %p, playlist %u%s\n",
          want ? "shown" : "hidden", (void *)list,
-         (unsigned)mod_djdb_playlist_now());
+         (unsigned)be_shown_playlist(),
+         list && be_under_playlist_view(list) ? " (PLAYLIST screen)" : "");
     be_g_shown = want;
     juce_comp_set_visible(be_g_btn, want);
 }

--- a/package/deck/mods/browse/sort.c
+++ b/package/deck/mods/browse/sort.c
@@ -116,6 +116,13 @@ static uintptr_t bs_find_visible(uintptr_t comp, uintptr_t ti, int depth)
     return 0;
 }
 
+uintptr_t bs_find_visible_class(uintptr_t comp, uintptr_t vt)
+{
+    uintptr_t ti = vt ? juce_class_of(vt) : 0;
+
+    return ti ? bs_find_visible(comp, ti, 0) : 0;
+}
+
 /* The header of whichever track list is on screen. NOT cached across a take:
  * which of the two lists is showing is exactly what changes between one press
  * and the next. */

--- a/package/deck/mods/db/db.h
+++ b/package/deck/mods/db/db.h
@@ -232,8 +232,11 @@ int mod_djdb_move_track_async(uint32_t playlist_id, int32_t from_no,
  * for: this names a WRITE's target and does not say what is on screen. [any] */
 uint32_t mod_djdb_playlist_now(void);
 
-/* The playlist whose list is on screen, or 0 -- the PLAYLIST-ONLY GATE. Only a
- * held cache counts, none of the fallbacks above. Quiet: polled. [any] */
+/* The PLAYLIST-ONLY GATE: the playlist the newest held track-list cache was
+ * asked for, 0 when that cache is another kind of list or none is held. One
+ * poll behind the screen, and the deck keeps the previous list's cache held
+ * for ~130 ms after replacing it, so the caller re-asks on a list change. None
+ * of the fallbacks above. Quiet: polled. [any] */
 uint32_t mod_djdb_playlist_shown(void);
 
 /* "The deck is inside a djdb operation right now, called from `where`" -- so the

--- a/package/deck/mods/db/db.h
+++ b/package/deck/mods/db/db.h
@@ -227,10 +227,14 @@ int mod_djdb_move_track_async(uint32_t playlist_id, int32_t from_no,
  * across playlists -- the held one follows the screen, and the newest one does
  * not, so the serial only ever breaks a tie.
  *
- * It is also the PLAYLIST-ONLY GATE: a list whose cache was not asked for with a
- * playlist hierarchy is not a playlist, and reordering one would be rewriting a
- * track's album number. [any] */
+ * Falls back, before a collector is seen, to the last playlist a query named
+ * and then to the medium's only playlist. Both outlive the list they were true
+ * for: this names a WRITE's target and does not say what is on screen. [any] */
 uint32_t mod_djdb_playlist_now(void);
+
+/* The playlist whose list is on screen, or 0 -- the PLAYLIST-ONLY GATE. Only a
+ * held cache counts, none of the fallbacks above. Quiet: polled. [any] */
+uint32_t mod_djdb_playlist_shown(void);
 
 /* "The deck is inside a djdb operation right now, called from `where`" -- so the
  * table registry can be read at a moment its context is certainly live, which is

--- a/package/deck/mods/db/djdb.c
+++ b/package/deck/mods/db/djdb.c
@@ -552,46 +552,53 @@ static int64_t djdb_wrap_cache_trim(uintptr_t self, uint32_t cap)
  * 0x14 caches at the top of every createListCache. */
 #define LCC_SANE_CACHES   64
 
-/* The id a single cached list was asked for, or 0 if it is not a playlist's. */
-static uint32_t djdb_cache_playlist(uintptr_t cache, uint32_t *serial)
+/* The source kind of a cached TRACK list (0 for any other cache), its serial,
+ * and -- for a playlist's -- the playlist id, else 0. */
+static uint16_t djdb_cache_kind(uintptr_t cache, uint32_t *serial, uint32_t *id)
 {
     uintptr_t cond, hb, he;
     uint16_t  kind;
-    uint32_t  id;
 
+    *id = 0;
     if (mod_safe_read(cache + LC_CONDITION, &cond, sizeof cond) != 0 || !cond)
         return 0;
     if (mod_safe_read(cond, &hb, sizeof hb) != 0 ||
         hb != ep122_sym(EP122_TRACK_LIST_CONDITION))
         return 0;
-    if (mod_safe_read(cond + TLC_KIND, &kind, sizeof kind) != 0 ||
-        kind != TLC_FROM_PLAYLIST)
+    if (mod_safe_read(cond + TLC_KIND, &kind, sizeof kind) != 0 || !kind)
         return 0;
+    mod_safe_read(cache + LC_SERIAL, serial, sizeof *serial);
+    if (kind != TLC_FROM_PLAYLIST)
+        return kind;
     if (mod_safe_read(cond + TLC_HIER, &hb, sizeof hb) != 0 ||
         mod_safe_read(cond + TLC_HIER_END, &he, sizeof he) != 0)
         return 0;
     if (he <= hb || (he - hb) % HIER_STEP)
-        return 0;
-    if (mod_safe_read(he - HIER_STEP + HIER_STEP_ID, &id, sizeof id) != 0 || !id)
-        return 0;
-    if (serial)
-        mod_safe_read(cache + LC_SERIAL, serial, sizeof *serial);
-    return id;
+        return kind;
+    mod_safe_read(he - HIER_STEP + HIER_STEP_ID, id, sizeof *id);
+    return kind;
 }
 
-/* The newest playlist list-cache, preferring one SOMEONE ELSE STILL HOLDS.
+/* The newest TRACK-LIST cache, preferring one SOMEONE ELSE STILL HOLDS, and the
+ * playlist it was asked for -- 0 when that newest cache is another kind of
+ * list (an album's, an artist's), even if a playlist's is still held beside it.
  *
  * Both halves are the collector's own vocabulary. The serial at +0x28 counts up
  * once per cached list, so the largest is the most recently opened. And the deck
  * purges caches whose use count is 1 -- see ListCacheCollector's own sweep --
  * because a use count of 1 means nobody but the collector is looking at it; the
- * list on screen is by definition held by something else.
+ * list on screen is held by something else. Measured (3.20): walking from a
+ * playlist into an album releases the playlist's cache about 130 ms after the
+ * album's list is on screen, so the newest held one is the honest answer and a
+ * held playlist alone is not.
  *
  * `*held`: the pick is a held one. `verbose`: log every candidate. */
 static uint32_t djdb_scan_caches(int verbose, int *held)
 {
+    static uint32_t told_serial;
     uintptr_t p, end;
     uint32_t  best = 0, best_serial = 0;
+    uint16_t  best_kind = 0;
     int       best_held = 0, seen = 0;
 
     *held = 0;
@@ -606,31 +613,39 @@ static uint32_t djdb_scan_caches(int verbose, int *held)
     for (; p < end; p += 16) {
         uintptr_t cache, ctrl;
         uint32_t  serial = 0, use = 0, id;
+        uint16_t  kind;
         int       is_held;
 
         if (mod_safe_read(p, &cache, sizeof cache) != 0 || !cache)
             continue;
-        id = djdb_cache_playlist(cache, &serial);
-        if (!id)
+        kind = djdb_cache_kind(cache, &serial, &id);
+        if (!kind)
             continue;
         if (mod_safe_read(p + 8, &ctrl, sizeof ctrl) == 0 && ctrl)
             mod_safe_read(ctrl + 8, &use, sizeof use);
         is_held = use > 1;
         seen++;
         if (verbose)
-            MDBG("djdb: cached list #%u is playlist %u, %s (use %u)\n",
-                 (unsigned)serial, (unsigned)id, is_held ? "held" : "loose",
-                 (unsigned)use);
+            MDBG("djdb: cached list #%u kind %u playlist %u, %s (use %u)\n",
+                 (unsigned)serial, (unsigned)kind, (unsigned)id,
+                 is_held ? "held" : "loose", (unsigned)use);
         if (is_held < best_held)
             continue;
         if (is_held > best_held || serial >= best_serial) {
             best = id;
             best_serial = serial;
+            best_kind = kind;
             best_held = is_held;
         }
     }
     if (verbose && !seen)
-        MDBG("djdb: the collector holds no playlist list-cache\n");
+        MDBG("djdb: the collector holds no track-list cache\n");
+    if (best_serial != told_serial) {
+        told_serial = best_serial;
+        MDBG("djdb: newest %s list-cache is #%u, kind %u, playlist %u\n",
+             best_held ? "held" : "loose", (unsigned)best_serial,
+             (unsigned)best_kind, (unsigned)best);
+    }
     *held = best_held;
     return best;
 }

--- a/package/deck/mods/db/djdb.c
+++ b/package/deck/mods/db/djdb.c
@@ -579,7 +579,7 @@ static uint32_t djdb_cache_playlist(uintptr_t cache, uint32_t *serial)
     return id;
 }
 
-/* The newest playlist list-cache SOMEONE ELSE STILL HOLDS.
+/* The newest playlist list-cache, preferring one SOMEONE ELSE STILL HOLDS.
  *
  * Both halves are the collector's own vocabulary. The serial at +0x28 counts up
  * once per cached list, so the largest is the most recently opened. And the deck
@@ -587,14 +587,14 @@ static uint32_t djdb_cache_playlist(uintptr_t cache, uint32_t *serial)
  * because a use count of 1 means nobody but the collector is looking at it; the
  * list on screen is by definition held by something else.
  *
- * Reported rather than assumed: every candidate is logged, so a wrong pick is
- * visible in the log rather than only in the DJ's playlist. */
-uint32_t djdb_playlist_from_caches(void)
+ * `*held`: the pick is a held one. `verbose`: log every candidate. */
+static uint32_t djdb_scan_caches(int verbose, int *held)
 {
     uintptr_t p, end;
     uint32_t  best = 0, best_serial = 0;
     int       best_held = 0, seen = 0;
 
+    *held = 0;
     if (!djdb_g_collector)
         return 0;
     if (mod_safe_read(djdb_g_collector + LCC_CACHES, &p, sizeof p) != 0 ||
@@ -606,7 +606,7 @@ uint32_t djdb_playlist_from_caches(void)
     for (; p < end; p += 16) {
         uintptr_t cache, ctrl;
         uint32_t  serial = 0, use = 0, id;
-        int       held;
+        int       is_held;
 
         if (mod_safe_read(p, &cache, sizeof cache) != 0 || !cache)
             continue;
@@ -615,22 +615,39 @@ uint32_t djdb_playlist_from_caches(void)
             continue;
         if (mod_safe_read(p + 8, &ctrl, sizeof ctrl) == 0 && ctrl)
             mod_safe_read(ctrl + 8, &use, sizeof use);
-        held = use > 1;
+        is_held = use > 1;
         seen++;
-        MDBG("djdb: cached list #%u is playlist %u, %s (use %u)\n",
-             (unsigned)serial, (unsigned)id, held ? "held" : "loose",
-             (unsigned)use);
-        if (held < best_held)
+        if (verbose)
+            MDBG("djdb: cached list #%u is playlist %u, %s (use %u)\n",
+                 (unsigned)serial, (unsigned)id, is_held ? "held" : "loose",
+                 (unsigned)use);
+        if (is_held < best_held)
             continue;
-        if (held > best_held || serial >= best_serial) {
+        if (is_held > best_held || serial >= best_serial) {
             best = id;
             best_serial = serial;
-            best_held = held;
+            best_held = is_held;
         }
     }
-    if (!seen)
+    if (verbose && !seen)
         MDBG("djdb: the collector holds no playlist list-cache\n");
+    *held = best_held;
     return best;
+}
+
+uint32_t djdb_playlist_from_caches(void)
+{
+    int held;
+
+    return djdb_scan_caches(1, &held);
+}
+
+uint32_t mod_djdb_playlist_shown(void)
+{
+    int held;
+    uint32_t id = djdb_scan_caches(0, &held);
+
+    return held ? id : 0;
 }
 
 void mod_djdb_drop_list_cache(uint32_t playlist_id)


### PR DESCRIPTION
Closes #3

The EDIT toggle in the browse header was gated on the sidebar having nine categories with PLAYLIST fourth. That is the shape of one stick's djdbMenuItems, not a property of the firmware, so on media with a different rail the toggle never appeared. The gate now asks whether the view is a playlist list, through the list cache the playlist view owns.

Tested: BROWSE → playlist and PLAYLIST button, both with and without a matching rail. Reported from Renesas 3.22; not run there.

---

**After review** (one more commit): the first version answered "some playlist cache is held", which stays true for about 130 ms after an album's list has replaced a playlist's, measured on the emulator: the widget is reused, the deck releases the old cache late, and EDIT showed on the album for that long. The scan now covers every track-list cache and answers from the newest held one, so an album's cache beside a still-held playlist's says album, and the browse side re-asks the moment the list on screen changes (pointer or row count). Re-tested playlist → album and artist → album: EDIT never appears on the album. The log no longer polls from inside a debug line, and docs/browsing.md says why playlists only.
