### PR TITLE
fix(cue): draw the GATE CUE shortcut as a filled plate in both states

### DIFF
--- a/docs/hot-cues.md
+++ b/docs/hot-cues.md
@@ -40,10 +40,13 @@ GATE CUE also has a button on the play screen, in the gap between the time
 display and the tempo, so you can arm it mid-set without going into a settings
 screen.
 
-It reads **white on the accent colour** while gate cue is on, and as an outline
-while it is off, the same two states A.HOT CUE and MT already use beside it.
+It reads **white on the accent colour** while gate cue is on, and as a grey
+plate with dim lettering while it is off. The grey is the one the deck's own
+STEMS, BEAT LOOP and KEY SHIFT buttons wear, which is how the deck marks a thing
+you can press; A.HOT CUE and MT beside it are outlines because they are
+indicators, not buttons.
 
-![Gate cue off: the GATE CUE button is an outline.](img/gate-shortcut-off.png)
+![Gate cue off: the GATE CUE button is a grey plate.](img/gate-shortcut-off.png)
 ![Gate cue on: the same button filled with the accent colour.](img/gate-shortcut-on.png)
 
 The button and the [MOD SETTINGS](mod-settings.md) row are the same switch, and

--- a/package/deck/mods/cue/shortcut.c
+++ b/package/deck/mods/cue/shortcut.c
@@ -77,6 +77,8 @@ static void cue_shortcut_paint(void *self, void *g)
     if (mod_ui_gen() != g_ink_gen)
         cue_shortcut_paint_state();
     if (juce_comp_bounds((uintptr_t)self, b) == 0) {
+        /* A flat fill, not the stipple the other plates wear: beside the timer
+         * and the tempo the texture read as a heavier control than it is. */
         mod_gfx_colour(g, g_gate_on ? ui->accent : ui->surface);
         mod_gfx_fill(g, 0, (b[3] - BTN_PLATE_H) / 2, b[2], BTN_PLATE_H);
     }
@@ -132,6 +134,9 @@ static void cue_shortcut_build(uintptr_t rack)
     g_btn = juce_label(rack, BTN_TEXT, BTN_FONT, 0x00000000u, mod_ui()->text_dim,
                        g_vptr, x, y, w, BTN_HIT_H);
     if (!g_btn) return;
+    /* Label::paint ends with a one-pixel outline in the LookAndFeel's colour;
+     * the plate is the whole of the drawing, so it is made invisible. */
+    juce_comp_colour(g_btn, LBL_COL_OUTLINE, 0x00000000u);
     g_rack = rack;
     cue_shortcut_paint_state();
     MDBG("cue_shortcut: GATE CUE shortcut at {%d,%d,%d,%d} in rack %#lx, plate %dpx\n",

--- a/package/deck/mods/cue/shortcut.c
+++ b/package/deck/mods/cue/shortcut.c
@@ -2,25 +2,16 @@
 /*
  * cue/shortcut.c - the GATE CUE shortcut on the play screen's bottom rack.
  *
- * The MOD SETTINGS row is three screens away from a deck that is playing, and
- * the gate is the one setting a DJ changes mid-set. This is the same flag with
- * a thumb on it: white on blue while the gate is armed, dim while it is not.
+ * The same flag as the MOD SETTINGS row, with a thumb on it: lettering on the
+ * accent while the gate is armed, dim lettering on the deck's unlit-button grey
+ * while it is not.
  *
- * Where it goes (RE-verified against EP122-3.19)
- * ----------------------------------------------
- * The rack is gui::NormalPlayerInfoWidget. It is NOT reachable by name: the
- * gui::PlayerInfo*Widget classes are UpdaterComponent models whose primary
- * vtable is nine slots of listener, and the juce::Component each of them also
- * IS lives at a secondary vtable. So the rack and its neighbours are found by
- * TYPEINFO, which every vtable in a class's group carries -- see juce.h.
- *
- * The button sits in the gap between the timer and the tempo, and the gap is
- * measured rather than written down: the timer's right edge and the tempo's
- * left edge come off the live components, so a firmware that moves either one
- * moves the button with it, and it is centred on the timer for the same reason.
- * Measured on 3.19, in rack coordinates, the timer is {395,13,327,80} and the
- * tempo {839,13,190,83} -- a 117px gap, with the SINGLE play-mode caption
- * {643,13,80,12} ending above it.
+ * The rack is gui::NormalPlayerInfoWidget. The gui::PlayerInfo*Widget classes
+ * are UpdaterComponent models whose juce::Component is a secondary subobject,
+ * so the rack and its neighbours are found by typeinfo (see juce.h). The plate
+ * sits in the gap between the timer and the tempo, both read off the live
+ * components so a firmware that moves them moves the plate. On 3.19, in rack
+ * coordinates: timer {395,13,327,80}, tempo {839,13,190,83}.
  */
 #include "cue/cue.h"
 #include "juce/juce.h"
@@ -28,35 +19,29 @@
 #include "theme/theme.h"
 #include "kit/mod.h"
 
-/* Identity of the three widgets this needs, as typeinfo. See juce.h for why the
- * vtable itself is the wrong handle for a model-first widget. */
+/* Typeinfo of the three widgets; see juce.h for why not the vtable. */
 #define RACK_TI   juce_class_of(ep122_sym(EP122_PLAYERINFO_RACK))
 #define TIME_TI   juce_class_of(ep122_sym(EP122_PLAYERINFO_TIME))
 #define TEMPO_TI  juce_class_of(ep122_sym(EP122_PLAYERINFO_TEMPO))
 
-/* The button, inside the measured gap. Insets keep it clear of both neighbours
- * rather than filling the space between them, which would read as a third
- * readout rather than as a control. */
-#define BTN_INSET_X   8
+/* Insets from the neighbours' boxes. Unequal because their ink is not at their
+ * box edges: the timer's last digit stops 1px short, the tempo's +/- sign (WIDE
+ * only) sits 5px inside. Gives 12px to the digits and 9px to the sign; on 3.19
+ * the plate lands at x=733, w=102. */
+#define BTN_INSET_L   11
+#define BTN_INSET_R   4
 
-/* Height is the plate's padding, and the rack's own badges set it: A.HOT CUE, MT
- * and +-10 are all 28px around lettering this size. A few px over that, because
- * unlike those three this one is pressed -- 28px is 4.4mm on the deck's glass,
- * which is under what a thumb hits reliably mid-set. Centred on the timer rather
- * than placed at a y of its own, so it sits on the row its neighbours sit on
- * whatever the firmware does with them. */
-#define BTN_H         32
+/* Plate 32px: the rack's badges are 28 but are read, not pressed. The label is
+ * BTN_HIT_H tall with the plate centred in it; the extra rows are transparent
+ * and only widen the touch target. Centred on the timer's box plus BTN_DROP,
+ * which puts the plate's centre on the badges' row (y=515 on 3.19). */
+#define BTN_PLATE_H   32
+#define BTN_HIT_H     36
+#define BTN_DROP      3
 #define BTN_MIN_W     70
 
-/* One line, at the size the rack sets its own captions in -- SINGLE and TEMPO on
- * either side, and A.HOT CUE, which fits nine characters in a box the same width
- * as this one.
- *
- * Sized with margin rather than to the edge: measured on the glass, "GATE CUE"
- * is 78px of the 91px juce::Label leaves inside a 101px box, so ~17.5 is where it
- * would start to squash. Label narrows text to its minimum horizontal scale
- * before it clips, so overshooting reads as a condensed font rather than as
- * something obviously wrong -- which is the failure worth leaving room against. */
+/* 15 draws 13px caps, AUTO CUE's height. "GATE CUE" is 76px of the 92px the
+ * Label leaves inside 102, and it starts to squash around 17.5. */
 #define BTN_FONT      15.0f
 #define BTN_TEXT      "GATE CUE"
 
@@ -65,32 +50,42 @@ static uintptr_t g_rack;
 static uintptr_t g_vptr;
 static uintptr_t g_vt[VT_CLONE_WORDS];
 static int       g_shown;               /* what the button is currently painted as */
+static unsigned  g_ink_gen;             /* the theme the label's lettering was set under */
 
-/* Lit is a filled accent plate with the deck's own lettering on it -- the same
- * shape as a selected DJ SETTING row, which is where a DJ has already learnt what
- * white-on-blue means here. Unlit is an outline and no fill, like A.HOT CUE and MT
- * two readouts away: an OFF shortcut belongs to the rack rather than sitting on it
- * as a second slab of grey.
- *
- * `text` rather than `text_on_accent` on the lit plate. That role is tuned for the
- * BYPASS amber, which is a light fill; the accent is the deck's blue and carries
- * white the way the deck's own does. A theme that made the accent light would want
- * the other role. */
+/* Fills: accent when lit, `surface` (the title-bar touch plates' grey) when
+ * not, both read from mod_ui() at paint time. Ink: `text_lit`, which follows
+ * the accent's polarity under a theme, or `text_dim`. The ink lives on the
+ * label and is restamped when the theme generation moves (cf. xpad_ink_sync). */
 static void cue_shortcut_paint_state(void)
 {
     const struct theme_ui *ui = mod_ui();
     int on = g_gate_on ? 1 : 0;
 
     if (!g_btn) return;
-    juce_comp_colour(g_btn, LBL_COL_BG,      on ? ui->accent : 0x00000000u);
-    juce_comp_colour(g_btn, LBL_COL_TEXT,    on ? ui->text   : ui->text_dim);
-    juce_comp_colour(g_btn, LBL_COL_OUTLINE, on ? 0x00000000u : ui->edge);
-    g_shown = on;
+    juce_comp_colour(g_btn, LBL_COL_TEXT, on ? ui->text_lit : ui->text_dim);
+    g_shown   = on;
+    g_ink_gen = mod_ui_gen();
 }
 
-/* The press. Toggles the same flag the MOD SETTINGS row owns, and persists it
- * for the same reason that row does -- a shortcut a restart silently undoes is
- * worse than no shortcut. */
+/* The plate first, then Label::paint for the lettering (the label's own
+ * background is transparent). Bracketed so the stored ink is not re-themed. */
+static void cue_shortcut_paint(void *self, void *g)
+{
+    const struct theme_ui *ui = mod_ui();
+    int32_t b[4];
+
+    if (mod_ui_gen() != g_ink_gen)
+        cue_shortcut_paint_state();
+    if (juce_comp_bounds((uintptr_t)self, b) == 0) {
+        mod_gfx_colour(g, g_gate_on ? ui->accent : ui->surface);
+        mod_gfx_fill(g, 0, (b[3] - BTN_PLATE_H) / 2, b[2], BTN_PLATE_H);
+    }
+    mod_draw_enter();
+    ((void (*)(void *, void *))LABEL_FN_PAINT)(self, g);
+    mod_draw_leave();
+}
+
+/* Toggles the flag the MOD SETTINGS row owns, and persists it. */
 static void cue_shortcut_mousedown(void *self, void *event)
 {
     (void)self; (void)event;
@@ -100,12 +95,12 @@ static void cue_shortcut_mousedown(void *self, void *event)
     MDBG("cue_shortcut: GATE CUE -> %s (shortcut)\n", g_gate_on ? "ON" : "OFF");
 }
 
-/* Build once, when the rack has both neighbours attached. A rack that is still
- * being wired up is simply not ready yet, and the next repaint tries again. */
+/* Built once the rack has both neighbours; until then the next repaint retries. */
 static void cue_shortcut_build(uintptr_t rack)
 {
     static const struct juce_vt_override ov[] = {
         { JUCE_VT_MOUSEDOWN, (void *)cue_shortcut_mousedown, NULL },
+        { JUCE_VT_PAINT,     (void *)cue_shortcut_paint,     NULL },
     };
     uintptr_t time_w, tempo_w;
     int32_t tb[4], pb[4];
@@ -121,9 +116,9 @@ static void cue_shortcut_build(uintptr_t rack)
     if (juce_comp_bounds(time_w, tb) != 0 || juce_comp_bounds(tempo_w, pb) != 0)
         return;
 
-    x = tb[0] + tb[2] + BTN_INSET_X;
-    w = pb[0] - x - BTN_INSET_X;
-    y = tb[1] + (tb[3] - BTN_H) / 2;
+    x = tb[0] + tb[2] + BTN_INSET_L;
+    w = pb[0] - x - BTN_INSET_R;
+    y = tb[1] + (tb[3] - BTN_PLATE_H) / 2 + BTN_DROP - (BTN_HIT_H - BTN_PLATE_H) / 2;
     if (w < BTN_MIN_W) {
         MDBG("cue_shortcut: only %dpx between the timer and the tempo -> no shortcut\n", w);
         g_rack = rack;                  /* remembered, so this is not retried per frame */
@@ -135,21 +130,17 @@ static void cue_shortcut_build(uintptr_t rack)
         if (!g_vptr) return;
     }
     g_btn = juce_label(rack, BTN_TEXT, BTN_FONT, 0x00000000u, mod_ui()->text_dim,
-                       g_vptr, x, y, w, BTN_H);
+                       g_vptr, x, y, w, BTN_HIT_H);
     if (!g_btn) return;
     g_rack = rack;
     cue_shortcut_paint_state();
-    MDBG("cue_shortcut: GATE CUE shortcut at {%d,%d,%d,%d} in rack %#lx\n",
-         x, y, w, BTN_H, (unsigned long)rack);
+    MDBG("cue_shortcut: GATE CUE shortcut at {%d,%d,%d,%d} in rack %#lx, plate %dpx\n",
+         x, y, w, BTN_HIT_H, (unsigned long)rack, BTN_PLATE_H);
 }
 
-/* Anchored on the waveform title bar's TouchAria, the same component the STEMS
- * row builds from and for the same reason: its paint fires once the play screen
- * is wired up, and the rack is a walk away from the root.
- *
- * Not the rack's own paint. The rack's juce::Component is a secondary subobject,
- * so there is no vtable in the spec that can be patched at the Component slot
- * numbering without writing over the listener vtable that shares its group. */
+/* Anchored on the waveform title bar's TouchAria paint, like the STEMS row: it
+ * fires once the play screen is wired up. The rack's own paint is unusable
+ * because its Component vtable shares a group with the listener vtable. */
 static uintptr_t g_orig_ta_paint;
 
 static void cue_shortcut_ta_paint(void *self, void *g)
@@ -164,8 +155,7 @@ static void cue_shortcut_ta_paint(void *self, void *g)
     }
 }
 
-/* The MOD SETTINGS row and the shortcut are two thumbs on one flag, so whichever
- * moves it tells the other. gate_cue.c hands this to its row as `changed`. */
+/* Called by the MOD SETTINGS row's `changed`, so both views of the flag agree. */
 void cue_shortcut_refresh(void)
 {
     if (g_btn && g_shown != (g_gate_on ? 1 : 0))

--- a/package/deck/mods/juce/draw.h
+++ b/package/deck/mods/juce/draw.h
@@ -163,6 +163,18 @@ struct theme_ui {
     uint32_t text_value;
     uint32_t text_off;        /* disabled lettering, greyed stems              */
     uint32_t text_on_accent;  /* near-black: white does not hold on a light fill */
+    /* Lettering on the ACCENT plate specifically. text_on_accent is not that, despite
+     * its name: every user puts it on one of the deck's BRIGHT chromatic fills (the
+     * BYPASS amber, the edit yellow, a stem colour), where the deck's own answer is
+     * near-black. The accent is the deck's blue, and on the deck's own selected row
+     * the lettering on it is white. The two fills have opposite polarity on ORIGINAL,
+     * so one role cannot serve both.
+     *
+     * Follows the fill's polarity, which is what the deck's own badges do under a
+     * theme: on WHITE the +-10 plate darkens and its black lettering turns white, so
+     * whichever of the theme's ink and ground is further from the accent is the one
+     * that goes on it. */
+    uint32_t text_lit;
     uint32_t dead;            /* "nothing here yet", darker than disabled      */
     uint32_t icon_disabled;
     uint32_t track;           /* progress rail, unfilled                       */

--- a/package/deck/mods/theme/roles.c
+++ b/package/deck/mods/theme/roles.c
@@ -124,7 +124,7 @@ static void derive(struct theme_ui *out, const struct theme_palette *pal)
     uint32_t w, k;
 
     /* Walked as a flat array of ARGB words on purpose. Every member is one, and naming
-     * each of the eighteen here would be a list to forget to extend -- a role added to
+     * each one here would be a list to forget to extend -- a role added to
      * the struct and not to this loop would silently come out black. */
     for (i = 0; i < n; i++)
         dst[i] = theme_palette_argb(pal, src[i], ROLE_IS_FILL);

--- a/package/deck/mods/theme/roles.c
+++ b/package/deck/mods/theme/roles.c
@@ -35,6 +35,10 @@
  *            white on it is the one combination on this deck that does not hold at arm's
  *            length. A theme with a dark accent should raise this.
  *
+ *   text_lit   White, for lettering on the ACCENT: the deck's selected DJ SETTING row is
+ *            white on its blue. Not text_on_accent, whose fills (amber, yellow, a stem)
+ *            are the bright ones -- opposite polarity on this deck, see draw.h.
+ *
  *   dead vs text_off   Two different absences. text_off is "switched off", dead is
  *            "nothing here yet", and dead is the darker of the two so the two states do
  *            not read alike.
@@ -71,6 +75,7 @@ const struct theme_ui k_ui_original = {
     .text_value     = 0xff7d7d7du,   /* a DJ SETTING row's value, measured off the list */
     .text_off       = 0xff6e6e6eu,
     .text_on_accent = 0xff1a1a1au,
+    .text_lit       = 0xffffffffu,   /* the deck's own lettering on its selected row */
     .dead           = 0xff3a3a3au,
     .icon_disabled  = 0xffb7b7b7u,
     .track          = 0xff3c3c3cu,
@@ -109,17 +114,30 @@ const struct theme_ui *mod_ui_stock(void)
     return &k_ui_original;
 }
 
+static uint32_t lum_gap(uint32_t a, uint32_t b);
+
 static void derive(struct theme_ui *out, const struct theme_palette *pal)
 {
     const uint32_t *src = (const uint32_t *)&k_ui_original;
     uint32_t *dst = (uint32_t *)out;
     unsigned i, n = sizeof(k_ui_original) / sizeof(uint32_t);
+    uint32_t w, k;
 
     /* Walked as a flat array of ARGB words on purpose. Every member is one, and naming
      * each of the eighteen here would be a list to forget to extend -- a role added to
      * the struct and not to this loop would silently come out black. */
     for (i = 0; i < n; i++)
         dst[i] = theme_palette_argb(pal, src[i], ROLE_IS_FILL);
+
+    /* The one role a palette cannot carry through: text_lit follows the ACCENT's
+     * polarity, and WHITE turns the deck's white lettering black while its blue plate,
+     * carved out, stays a blue -- black on blue, measured on the GATE CUE plate. The
+     * deck's own +-10 badge under the same palette darkens its fill and turns its
+     * lettering white, which is the rule: of the deck's white and black through this
+     * palette, the one further from the accent goes on it. */
+    w = theme_palette_argb(pal, 0xffffffffu, ROLE_IS_FILL);
+    k = theme_palette_argb(pal, 0xff000000u, ROLE_IS_FILL);
+    out->text_lit = lum_gap(out->accent, w) >= lum_gap(out->accent, k) ? w : k;
 }
 
 /* ================================================================== */
@@ -300,6 +318,10 @@ void theme_ui_expand(struct theme_ui *out, const struct theme_palette *pal,
      * subtractions and cannot be wrong. */
     out->text_on_accent = lum_gap(out->accent, sd->ink) > lum_gap(out->accent, sd->ground)
                           ? sd->ink : sd->ground;
+    /* The same measurement, kept as its own role because on ORIGINAL the two fills it
+     * and text_on_accent sit on have opposite polarity (see draw.h). Here the accent is
+     * the only fill measured, so the two agree -- by construction, not by accident. */
+    out->text_lit       = out->text_on_accent;
     (void)light;
     out->dead           = toward(out->surface, down, 96);  /* "nothing here yet": below the plate */
     out->icon_disabled  = toward(sd->ink, down, 110);

--- a/package/deck/mods/xpad/pane.c
+++ b/package/deck/mods/xpad/pane.c
@@ -22,9 +22,8 @@
  * is what these were before.
  *
  * The lamp carries the state and the word never changes shape -- only its
- * brightness, from the deck's dim lettering to its full white, which is the same
- * pair GATE CUE uses one rack below. The lamp's own frame is one pixel of `edge`,
- * no fill, until it lights.
+ * brightness, from the deck's dim lettering to its full white. The lamp's own
+ * frame is one pixel of `edge`, no fill, until it lights.
  *
  * BOTH LIGHT THE SAME WAY. OVERDUB blinked here for a while, after the RMX's own
  * recording signal, and it was wrong on a screen: a lamp caught on the dim half

--- a/package/deck/mods/xpad/pane.c
+++ b/package/deck/mods/xpad/pane.c
@@ -23,8 +23,8 @@
  *
  * The lamp carries the state and the word never changes shape -- only its
  * brightness, from the deck's dim lettering to its full white, which is the same
- * pair GATE CUE uses one rack below. The lamp's own frame is GATE CUE's too: one
- * pixel of `edge`, no fill, until it lights.
+ * pair GATE CUE uses one rack below. The lamp's own frame is one pixel of `edge`,
+ * no fill, until it lights.
  *
  * BOTH LIGHT THE SAME WAY. OVERDUB blinked here for a while, after the RMX's own
  * recording signal, and it was wrong on a screen: a lamp caught on the dim half

--- a/package/deck/mods/xpad/xpad.h
+++ b/package/deck/mods/xpad/xpad.h
@@ -143,8 +143,8 @@ extern "C" {
  * a steady one reads as a control mid-change, not as a recorder. */
 #define XP_FLAG_W       132     /* OVERDUB / HOLD, stacked                      */
 #define XP_FLAG_GAP     8
-/* One pixel, which is what juce::Label's own drawRect gives GATE CUE and every
- * other outlined plate on the rack. */
+/* One pixel, which is what juce::Label's own drawRect gives every outlined plate
+ * on the rack. */
 #define XP_FLAG_EDGE    1
 #define XP_LAMP_PAD     4       /* the lamp's inset within the row              */
 #define XP_LAMP_GAP     9       /* ...and the air between it and the word       */

--- a/package/deck/tests/test_theme.c
+++ b/package/deck/tests/test_theme.c
@@ -22,6 +22,7 @@ static const char *const k_role_name[] = {
     "xpad", "xpad_on",
     "stem[0]", "stem[1]", "stem[2]",
     "text", "text_deck", "text_dim", "text_value", "text_off", "text_on_accent",
+    "text_lit",
     "dead", "icon_disabled", "track", "tick", "mark", "warn", "refuse",
     "bar", "bar_on"
 };

--- a/package/deck/tests/test_theme.c
+++ b/package/deck/tests/test_theme.c
@@ -196,8 +196,10 @@ static void roles_stay_legible(void)
         CHECK(u->stem[0] != u->stem[1]);
         CHECK(u->stem[1] != u->stem[2]);
         CHECK(u->stem[0] != u->stem[2]);
-        /* Lettering has to stand off the plate it sits on. */
+        /* Lettering has to stand off the plate it sits on: dim ink on the
+         * surface, lit ink on the accent (GATE CUE's plate when it is on). */
         CHECK(distance(u->text, u->surface) >= 64);
+        CHECK(distance(u->text_lit, u->accent) >= 64);
         /* warn and refuse have to stay tellable apart. */
         CHECK(u->warn != u->refuse);
 


### PR DESCRIPTION
Closes #7

The play-screen GATE CUE shortcut is now a filled plate in both states: the deck's unlit-button grey with dim lettering when off, the accent with lit lettering when on. Spacing to the timer's last digit and the tempo's ± sign is symmetric. Plate 32×102 at 733/515 on 3.19, touch target 36 px tall, lettering at AUTO CUE's cap height in the deck's own typeface.

Grey OFF, symmetric spacing and lettering size follow the reporter's revision; the plate stays 32 rather than 28 because it is a touch control, not a badge. The 3000X's lettering is a different typeface the deck does not ship and was deliberately not imitated.

Tested on the rk3399 3.20 emulator. The two doc screenshots still show the old outline and will be re-captured in a doc pass after merge.

---

**After review** (one more commit): the label's outline colour is set transparent at build, as every other label plate in the repo does, since Label::paint closes with a one-pixel rectangle in the LookAndFeel's colour; the theme test asserts `text_lit` stays off `accent` by the same margin `text` keeps off `surface`. The plate stays a flat fill by choice, stated in the paint: beside the timer and the tempo the stipple reads as a heavier control than it is.
