### PR TITLE
fix(stem): float WAV, VBR MP3 length, and the offline cache

### DIFF
--- a/docs/stems.md
+++ b/docs/stems.md
@@ -60,17 +60,19 @@ a stick prepared on one deck plays on another.
 
 ### The frame count, for anyone writing entries offline
 
-Half of an entry's key is the deck's own decode length in frames, and the stems
-inside it must be aligned to that length. It is not the length a tag or another
-decoder reports:
+Half of an entry's key is the deck's own decode length in frames **at
+44.1 kHz**, and the stems inside it must be aligned to that length. It is not
+the length a tag or another decoder reports. Take the container's count, then
+round it up:
 
-- **Every container:** the decoder's length rounded **up** to the next 1/75 s —
-  588 samples at 44.1 kHz.
 - **MP3:** Pioneer's parser frame count × 1152. A LAME/Xing tag frame counts as
   a frame of audio (one frame of silence first, the last frame dropped); an
   ffmpeg-written one does not. This is the same number rekordbox stores as the
   analysis's PVBR total.
 - **AAC:** packets × 1024, with the priming samples played.
+- **Then, every container:** rounded **up** to the next 1/75 s, which is 588
+  samples at 44.1 kHz. A 9190-frame MP3 is 10 586 880 samples, and the key is
+  18 005 × 588 = 10 586 940.
 
 Worked out on a CDJ-3000 from 16 loads and verified sample-for-sample against 4
 uploads; the MP3 rule checks against the PVBR totals on an exported stick. Write

--- a/docs/stems.md
+++ b/docs/stems.md
@@ -54,7 +54,29 @@ stems are on the stick, so it loads with no server on the network at all.
 **Stems live on the same volume as the track.** They are keyed by the track's
 own contents, not by its filename or its position in the browser, so renaming a
 file, reorganising folders or re-sorting the list all keep the cache valid, and
-pulling a stick takes its tracks and their stems away together.
+pulling a stick takes its tracks and their stems away together. A pair made by
+a different separation model than the one your deck last used is used too, so
+a stick prepared on one deck plays on another.
+
+### The frame count, for anyone writing entries offline
+
+Half of an entry's key is the deck's own decode length in frames, and the stems
+inside it must be aligned to that length. It is not the length a tag or another
+decoder reports:
+
+- **Every container:** the decoder's length rounded **up** to the next 1/75 s —
+  588 samples at 44.1 kHz.
+- **MP3:** Pioneer's parser frame count × 1152. A LAME/Xing tag frame counts as
+  a frame of audio (one frame of silence first, the last frame dropped); an
+  ffmpeg-written one does not. This is the same number rekordbox stores as the
+  analysis's PVBR total.
+- **AAC:** packets × 1024, with the priming samples played.
+
+Worked out on a CDJ-3000 from 16 loads and verified sample-for-sample against 4
+uploads; the MP3 rule checks against the PVBR totals on an exported stick. Write
+the stems as **96 kHz FLAC**: a pair at the deck's own rate loads in a few
+seconds, where a pair the deck has to resample takes about a third of the
+track's length.
 
 ### Playing from another player's media
 

--- a/package/deck/mods/core/ep122_syms.h
+++ b/package/deck/mods/core/ep122_syms.h
@@ -59,6 +59,7 @@ enum ep122_sym {
     EP122_READER_MP4,
     EP122_READER_AIFF,
     EP122_READER_WAV,
+    EP122_READER_JUCE,
     EP122_FACTORY_FLAC,
     EP122_FACTORY_MP3,
     EP122_FACTORY_AAC,
@@ -298,6 +299,7 @@ static const struct ep122_vt_spec {
     { EP122_READER_MP4, "N12audio_format11FileReadMp4E", NULL },   /* 0x1f14908 */
     { EP122_READER_AIFF, "N12audio_format12FileReadAiffE", NULL },   /* 0x1f13d78 */
     { EP122_READER_WAV, "N12audio_format11FileReadWavE", NULL },   /* 0x1f13b80 */
+    { EP122_READER_JUCE, "N12audio_format22JuceAudioReaderWrapperE", NULL },   /* 0x1f15318 */
     { EP122_FACTORY_FLAC, "N12audio_format19FileReadFlacFactoryE", NULL },   /* 0x1f139c0 */
     { EP122_FACTORY_MP3, "N12audio_format18FileReadMp3FactoryE", NULL },   /* 0x1f13948 */
     { EP122_FACTORY_AAC, "N12audio_format18FileReadAacFactoryE", NULL },   /* 0x1f13970 */
@@ -630,6 +632,7 @@ static const char *const k_ep122_sym_name[] = {
     "READER_MP4",
     "READER_AIFF",
     "READER_WAV",
+    "READER_JUCE",
     "FACTORY_FLAC",
     "FACTORY_MP3",
     "FACTORY_AAC",

--- a/package/deck/mods/core/ep122_syms.spec
+++ b/package/deck/mods/core/ep122_syms.spec
@@ -163,6 +163,11 @@ vtable READER_ALAC        class=N12audio_format12FileReadAlacE
 vtable READER_MP4         class=N12audio_format11FileReadMp4E
 vtable READER_AIFF        class=N12audio_format12FileReadAiffE
 vtable READER_WAV         class=N12audio_format11FileReadWavE
+# The fallback behind the seven: what AudioReaderFactory builds when no native
+# factory takes a file -- a 32-bit float WAV, which FileReadWav refuses and the
+# deck still plays. Same AbstractReader interface, same open() slot, so the
+# capture sees the open the deck actually succeeded with.
+vtable READER_JUCE        class=N12audio_format22JuceAudioReaderWrapperE
 vtable FACTORY_FLAC       class=N12audio_format19FileReadFlacFactoryE
 vtable FACTORY_MP3        class=N12audio_format18FileReadMp3FactoryE
 vtable FACTORY_AAC        class=N12audio_format18FileReadAacFactoryE

--- a/package/deck/mods/stem/cache.c
+++ b/package/deck/mods/stem/cache.c
@@ -400,7 +400,16 @@ static int store_root(const char *track_path, char *out, size_t cap,
     return -1;
 }
 
-/* Where a track's entry sits under a given root. Creates nothing. */
+/* Where a key's entry sits under a root, for one separation id. */
+static int entry_dir(const char *root, const char *sep_id, const char *key,
+                     char *out, size_t cap)
+{
+    return (size_t)snprintf(out, cap, "%s/%s/%s/%c%c/%s", root, CACHE_ROOT,
+                            sep_id, key[0], key[1], key) < cap ? 0 : -1;
+}
+
+/* Where a track's entry sits under a given root, for the CURRENT separation
+ * id -- the store's question. Creates nothing. */
 static int entry_path(const char *root, const char *track_path, int64_t frames,
                       char *out, size_t cap)
 {
@@ -410,10 +419,7 @@ static int entry_path(const char *root, const char *track_path, int64_t frames,
         return -1;                    /* no server has ever identified itself */
     if (key_of(track_path, frames, key, sizeof(key)) != 0)
         return -1;
-    if ((size_t)snprintf(out, cap, "%s/%s/%s/%c%c/%s", root, CACHE_ROOT,
-                         g_stem_sep_id, key[0], key[1], key) >= cap)
-        return -1;
-    return 0;
+    return entry_dir(root, g_stem_sep_id, key, out, cap);
 }
 
 /* ---- meta ----------------------------------------------------------------- */
@@ -498,45 +504,78 @@ static int find_part(const char *dir, const char *stem, char *out, size_t cap)
     return -1;
 }
 
+/* One entry directory: 0 and `out` filled when it holds a usable pair. */
+static int try_entry(const char *dir, int64_t frames, struct stem_cache_entry *out)
+{
+    int64_t meta_frames = 0;
+
+    if (meta_read(dir, &meta_frames, &out->harmonics_gain,
+                  &out->vocals_gain) != 0)
+        return -1;
+    /* The key already covers the frame count, so a disagreement here means an
+     * entry written by something that did not agree with us about what the key
+     * means. Skip it rather than reason about it -- another may still be good. */
+    if (meta_frames != frames) {
+        MDBG("stem_cache: %s frames %lld != %lld, ignoring entry\n",
+             dir, (long long)meta_frames, (long long)frames);
+        return -1;
+    }
+    if (find_part(dir, "harmonics", out->harmonics_path,
+                  sizeof(out->harmonics_path)) != 0 ||
+        find_part(dir, "vocals", out->vocals_path,
+                  sizeof(out->vocals_path)) != 0)
+        return -1;
+    MDBG("stem_cache: HIT %s\n", dir);
+    return 0;
+}
+
 int stem_cache_lookup(const char *track_path, int64_t frames,
                       struct stem_cache_entry *out)
 {
     char roots[MAX_ROOTS][STEM_CACHE_PATH_MAX];
-    char dir[STEM_CACHE_PATH_MAX];
+    char dir[STEM_CACHE_PATH_MAX], base[STEM_CACHE_PATH_MAX];
+    char key[20];
     int n, i;
 
     if (!track_path || !track_path[0] || frames <= 0 || !out)
         return -1;
+    if (key_of(track_path, frames, key, sizeof(key)) != 0)
+        return -1;
 
     /* Every candidate, not the first volume that happens to hold a cache: the
      * local stick can be full of other tracks while the stems for the one now
-     * playing sit on a linked player's media. */
+     * playing sit on a linked player's media.
+     *
+     * And under each, EVERY separation id, the current one first. The id only
+     * says which model made the pair; the key is the track and the meta is the
+     * alignment, so a pair another model made is a pair this track can play.
+     * Without this a deck that last spoke to the server under one model could
+     * not read what its own stick holds under another, and two linked decks
+     * with different ids could not share a cache at all -- offline, that was
+     * the whole feature gone. */
     n = collect_roots(roots, MAX_ROOTS);
     for (i = 0; i < n; i++) {
-        int64_t meta_frames = 0;
+        struct dirent *de;
+        DIR *d;
 
-        if (entry_path(roots[i], track_path, frames, dir, sizeof(dir)) != 0)
+        if (g_stem_sep_id[0] &&
+            entry_dir(roots[i], g_stem_sep_id, key, dir, sizeof(dir)) == 0 &&
+            try_entry(dir, frames, out) == 0)
+            return 0;
+
+        if ((size_t)snprintf(base, sizeof(base), "%s/%s", roots[i], CACHE_ROOT)
+                >= sizeof(base) || !(d = opendir(base)))
             continue;
-        if (meta_read(dir, &meta_frames, &out->harmonics_gain,
-                      &out->vocals_gain) != 0)
-            continue;
-        /* The key already covers the frame count, so a disagreement here means
-         * an entry written by something that did not agree with us about what
-         * the key means. Skip it rather than reason about it -- another volume
-         * may still hold a good one. */
-        if (meta_frames != frames) {
-            MDBG("stem_cache: %s frames %lld != %lld, ignoring entry\n",
-                 dir, (long long)meta_frames, (long long)frames);
-            continue;
+        while ((de = readdir(d)) != NULL) {
+            if (de->d_name[0] == '.' || !strcmp(de->d_name, g_stem_sep_id))
+                continue;
+            if (entry_dir(roots[i], de->d_name, key, dir, sizeof(dir)) == 0 &&
+                try_entry(dir, frames, out) == 0) {
+                closedir(d);
+                return 0;
+            }
         }
-        if (find_part(dir, "harmonics", out->harmonics_path,
-                      sizeof(out->harmonics_path)) != 0 ||
-            find_part(dir, "vocals", out->vocals_path,
-                      sizeof(out->vocals_path)) != 0)
-            continue;
-
-        MDBG("stem_cache: HIT %s\n", dir);
-        return 0;
+        closedir(d);
     }
     return -1;
 }

--- a/package/deck/mods/stem/decode.c
+++ b/package/deck/mods/stem/decode.c
@@ -180,6 +180,10 @@ static struct reader_vt g_reader[] = {
     { "Mp4",  EP122_READER_MP4,  0, 0 },
     { "Aiff", EP122_READER_AIFF, 0, 0 },
     { "Wav",  EP122_READER_WAV,  0, 0 },
+    /* The factory's fallback for what the seven refuse -- a 32-bit float WAV
+     * among them. The deck plays those through it, so this is the open that
+     * succeeds for such a track, and the only one that names its path. */
+    { "Juce", EP122_READER_JUCE, 0, 0 },
 };
 #define N_READER_VT ((int)(sizeof(g_reader) / sizeof(g_reader[0])))
 
@@ -228,6 +232,16 @@ static unsigned g_open_calls;
  * g_cap.path, which the reporter consumes and clears; the decode worker needs
  * the path to stay valid for as long as the track is loaded. */
 static char g_track_path[PATH_MAX_CAP];
+
+/* Set the instant a SUCCESSFUL deck open refreshes g_track_path, cleared the
+ * first time a new sourceId consumes it. A track whose OWN open failed never
+ * sets it, so g_track_path still points at the previous, successfully-opened
+ * track -- and a new id must NOT bind to that stale path. Consume-once is what
+ * tells "the deck just opened this track" apart from "g_track_path is left over
+ * from a different song": only the former is fresh. Written from the page-filler
+ * thread with RELEASE after the memcpy, read from the message thread with
+ * ACQUIRE, so a reader that sees fresh=1 also sees the path bytes. */
+static int g_track_fresh;
 
 /* Set while THIS thread is inside stem_decode_pull.
  *
@@ -380,7 +394,11 @@ static int stem_reader_open(void *self, const void *path, const void *seek_table
     if (!g_decode_self)
         __atomic_store_n(&g_deck_open_ms, decode_now_ms(), __ATOMIC_RELEASE);
 
-    if (!g_cap.pending) {
+    /* A failed open holds the capture only until one succeeds. The factory
+     * falls through its readers -- FileReadWav refuses a float WAV and the JUCE
+     * wrapper takes it -- and the open that succeeded is the one that names the
+     * track; keeping the first would report the refusal and lose the path. */
+    if (!g_cap.pending || (!g_cap.ret && ret)) {
         uintptr_t rate_fn = 0;
 
         g_cap.which = which;
@@ -397,8 +415,10 @@ static int stem_reader_open(void *self, const void *path, const void *seek_table
          * track. g_cap still records it, because seeing those opens in the log
          * is how the stem decode is debugged; only the thing that decides what
          * gets uploaded is protected. */
-        if (ret && g_cap.path[0] && !g_decode_self)
+        if (ret && g_cap.path[0] && !g_decode_self) {
             memcpy(g_track_path, g_cap.path, sizeof(g_track_path));
+            __atomic_store_n(&g_track_fresh, 1, __ATOMIC_RELEASE);
+        }
 
         /* Read the field the stock getter would have returned, but only once
          * the slot has confirmed it IS that getter -- an override would mean
@@ -568,8 +588,17 @@ const char *stem_decode_path_for_sid(uint64_t lo, uint64_t hi)
             return g_bind[i].path;
 
     /* Unseen id: it must be the track the deck just opened, because an open is
-     * the only way a new source enters the pool. */
-    if (!g_track_path[0])
+     * the only way a new source enters the pool -- but ONLY if that open
+     * succeeded and left a fresh path. A float WAV (or any format this reader
+     * cannot open) fails its open, so g_track_path still holds the PREVIOUS
+     * track; binding this id to it publishes that song's stems over the wrong
+     * one. Consume the freshness so a second new id in the same gap -- a
+     * re-served track has its own binding already and never reaches here --
+     * cannot inherit it either. No fresh path means no stems, and the caller
+     * dropping the resident set on a NULL is what stops the last song's faders
+     * from bleeding through. */
+    if (!g_track_path[0] ||
+        !__atomic_exchange_n(&g_track_fresh, 0, __ATOMIC_ACQ_REL))
         return NULL;
 
     i = g_bind_next++ % SID_BINDS;

--- a/package/deck/mods/stem/decode.c
+++ b/package/deck/mods/stem/decode.c
@@ -27,10 +27,9 @@
  * arguments - no analysis data synthesised, no reader shared with the player,
  * and no lifetime entanglement with the page filler's copy.
  *
- * This TU is currently an OBSERVATION PROBE: it records and chains, and creates
- * nothing. It exists to confirm what the arguments actually are, because
- * everything above is read off the decompiler and the argument identities in
- * particular are inference.
+ * The hook records what every open() was handed (the reporter prints it) and
+ * keeps, for the track the deck opened last, the path and those two tables;
+ * stem_decode_pull hands them back to createReaderFor for that path.
  *
  * Threading: `open` runs on the page-filler thread, which the track loader
  * blocks on - stall it and the load times out in
@@ -50,8 +49,8 @@
  *
  * Found by walking RTTI base arrays (scripts/ep122sym.py impls
  * audio_format::AbstractReader), which is also how we know the list is complete.
- * Every concrete reader inherits the same `open` - one function, nine vtables -
- * so the wrapper is shared and only the slots differ.
+ * The seven file readers share AbstractFileReader::open; the JUCE wrapper has
+ * its own. One wrapper serves all eight, telling them apart by vptr.
  *
  *   bool open(const juce::String &path, const audio_format::SeekTable &,
  *             const audio_format::FrameInfoList &)
@@ -248,9 +247,12 @@ static int g_track_fresh;
  * to createReaderFor so our reader opens against the same analysis the deck's
  * did -- for a VBR MP3 that is what lets setSource size it, since the reader
  * alone carries no length. Captured on the SAME successful open as g_track_path
- * so the three always describe one track, and only used when the probe's path
- * still matches -- the deck keeps the loaded track's analysis alive, so the
- * pointer is live for as long as that path is what is playing. */
+ * so the three always describe one track, and only used while the pull's path
+ * still matches, i.e. for the track the deck has loaded and whose analysis it
+ * is holding. They are read during createReaderFor only: the MP3 reader builds
+ * its own frame index from them at open (sub_a47b20), so the exposure is that
+ * call, not the decode that follows. Never used for a re-served track: nothing
+ * says the deck still holds the analysis it handed over the first time. */
 static uintptr_t g_track_seek;
 static uintptr_t g_track_frame;
 
@@ -599,8 +601,15 @@ const char *stem_decode_path_for_sid(uint64_t lo, uint64_t hi)
     int i;
 
     for (i = 0; i < SID_BINDS; i++)
-        if (g_bind[i].used && g_bind[i].lo == lo && g_bind[i].hi == hi)
+        if (g_bind[i].used && g_bind[i].lo == lo && g_bind[i].hi == hi) {
+            /* A reload of a track the pool had evicted opens it again, which
+             * set the flag; this binding is that open's, so spend it here or
+             * the next reader-less load inherits it and binds to this path. */
+            if (__atomic_load_n(&g_track_fresh, __ATOMIC_ACQUIRE) &&
+                strcmp(g_bind[i].path, g_track_path) == 0)
+                __atomic_store_n(&g_track_fresh, 0, __ATOMIC_RELEASE);
             return g_bind[i].path;
+        }
 
     /* Unseen id: it must be the track the deck just opened, because an open is
      * the only way a new source enters the pool -- but ONLY if that open
@@ -684,7 +693,8 @@ int64_t stem_decode_pull(const char *path, int rate, stem_pcm_sink_fn sink,
     frame_arg = frame_stub;
     cap_seek = __atomic_load_n(&g_track_seek, __ATOMIC_ACQUIRE);
     cap_frame = __atomic_load_n(&g_track_frame, __ATOMIC_ACQUIRE);
-    if (cap_seek && g_track_path[0] && strcmp(path, g_track_path) == 0) {
+    if (cap_seek && cap_frame && g_track_path[0] &&
+        strcmp(path, g_track_path) == 0) {
         seek_arg = (const void *)cap_seek;
         frame_arg = (const void *)cap_frame;
         MDBG("stem_decode: reusing deck seekTable=%#lx frameInfo=%#lx\n",

--- a/package/deck/mods/stem/decode.c
+++ b/package/deck/mods/stem/decode.c
@@ -243,6 +243,17 @@ static char g_track_path[PATH_MAX_CAP];
  * ACQUIRE, so a reader that sees fresh=1 also sees the path bytes. */
 static int g_track_fresh;
 
+/* The SeekTable and FrameInfoList the deck built for g_track_path -- open()'s
+ * 2nd and 3rd arguments, which the worker cannot invent. Both are handed back
+ * to createReaderFor so our reader opens against the same analysis the deck's
+ * did -- for a VBR MP3 that is what lets setSource size it, since the reader
+ * alone carries no length. Captured on the SAME successful open as g_track_path
+ * so the three always describe one track, and only used when the probe's path
+ * still matches -- the deck keeps the loaded track's analysis alive, so the
+ * pointer is live for as long as that path is what is playing. */
+static uintptr_t g_track_seek;
+static uintptr_t g_track_frame;
+
 /* Set while THIS thread is inside stem_decode_pull.
  *
  * The open hook is global: it fires for every reader the factory builds, and we
@@ -417,6 +428,10 @@ static int stem_reader_open(void *self, const void *path, const void *seek_table
          * gets uploaded is protected. */
         if (ret && g_cap.path[0] && !g_decode_self) {
             memcpy(g_track_path, g_cap.path, sizeof(g_track_path));
+            /* Same open as the path: the analysis these describe is this
+             * track's, and the worker hands both back to createReaderFor. */
+            __atomic_store_n(&g_track_seek, (uintptr_t)seek_table, __ATOMIC_RELEASE);
+            __atomic_store_n(&g_track_frame, (uintptr_t)frame_info, __ATOMIC_RELEASE);
             __atomic_store_n(&g_track_fresh, 1, __ATOMIC_RELEASE);
         }
 
@@ -631,10 +646,15 @@ int64_t stem_decode_pull(const char *path, int rate, stem_pcm_sink_fn sink,
     /* juce::String is a single pointer; the second word is slack so a wrong
      * guess about its size cannot scribble on the frame. */
     uintptr_t jstr[2] = { 0, 0 };
-    /* FileReadFlac ignores open()'s 2nd and 3rd arguments outright. Zeroed
-     * stand-ins keep the call well-formed for the formats that do read them,
-     * and this path is only claimed for FLAC until that is tested. */
+    /* FileReadFlac ignores open()'s 2nd and 3rd arguments outright, so zeroed
+     * stand-ins are enough for it. A VBR MP3 is not: its length comes out of the
+     * SeekTable/FrameInfoList, and with stubs setSource reports -1 frames and the
+     * job never starts. So when the deck has already opened THIS track we reuse
+     * the very tables it built (g_track_seek/g_track_frame); the stubs remain the
+     * fallback for a track the deck has not opened for us to observe. */
     uint8_t seek_stub[64], frame_stub[64];
+    const void *seek_arg, *frame_arg;
+    uintptr_t cap_seek, cap_frame;
     int32_t err = 0;
     void *reader = NULL, *src = NULL;
     float *buf = NULL;
@@ -655,6 +675,22 @@ int64_t stem_decode_pull(const char *path, int rate, stem_pcm_sink_fn sink,
     memset(seek_stub, 0, sizeof(seek_stub));
     memset(frame_stub, 0, sizeof(frame_stub));
 
+    /* Reuse the deck's own analysis for this track when we have it; the stubs
+     * otherwise. strcmp against g_track_path is what ties the tables to the file
+     * being decoded -- a mismatch (a re-served track the deck never re-opened,
+     * or our own stem files) falls back rather than handing MP3 a stranger's
+     * SeekTable. */
+    seek_arg = seek_stub;
+    frame_arg = frame_stub;
+    cap_seek = __atomic_load_n(&g_track_seek, __ATOMIC_ACQUIRE);
+    cap_frame = __atomic_load_n(&g_track_frame, __ATOMIC_ACQUIRE);
+    if (cap_seek && g_track_path[0] && strcmp(path, g_track_path) == 0) {
+        seek_arg = (const void *)cap_seek;
+        frame_arg = (const void *)cap_frame;
+        MDBG("stem_decode: reusing deck seekTable=%#lx frameInfo=%#lx\n",
+             (unsigned long)cap_seek, (unsigned long)cap_frame);
+    }
+
     if (sink)
         buf = malloc((size_t)DECODE_CHUNK * 2 * sizeof(float));
     src = malloc(SRC_SIZE);
@@ -669,7 +705,7 @@ int64_t stem_decode_pull(const char *path, int rate, stem_pcm_sink_fn sink,
     t0 = decode_cntvct();
     reader = ((create_reader_fn_t)FN_CREATE_READER)((void *)ADDR_READER_FACTORY,
                                                     jstr, &err, 1,
-                                                    seek_stub, frame_stub,
+                                                    seek_arg, frame_arg,
                                                     (uint64_t)g_factory_kind);
     dt = decode_cntvct() - t0;
     if (!reader) {
@@ -725,23 +761,8 @@ int64_t stem_decode_pull(const char *path, int rate, stem_pcm_sink_fn sink,
          * path when they differ. */
         rc = ((fileread_fn_t)fn_fileread)(src, pos, buf, want);
         if (rc != 0) {
-            MDBG("stem_decode: fileRead rc=%d at frame %lld of %lld\n", rc,
-                 (long long)pos, (long long)out_len);
-            /* Stop and report what was actually delivered. NOT a judgement about
-             * whether that is enough -- this function cannot make it.
-             *
-             * out_len is the converter's ESTIMATE, derived from an in_len that
-             * includes the decoder's own pad (17538276 = 17534160 + 4116 here),
-             * so it always asks for a little more than the source can yield, by
-             * an amount that varies per track: 2816 frames on one, 7936 on the
-             * next. Every threshold guessed here was just a number wide enough
-             * for the tracks that had been tried.
-             *
-             * The caller knows the real frame count -- from the cache entry's
-             * meta, or from what JOB_BEGIN committed to -- so the caller does
-             * the checking, against a fact rather than an estimate. */
-            MDBG("stem_decode: stream ended at %lld of an estimated %lld\n",
-                 (long long)pos, (long long)out_len);
+            MDBG("stem_decode: fileRead rc=%d, stream ended at %lld of %lld\n",
+                 rc, (long long)pos, (long long)out_len);
             break;
         }
         if (sink(buf, want, user) != 0) {

--- a/package/deck/mods/stem/ipc.c
+++ b/package/deck/mods/stem/ipc.c
@@ -14,6 +14,7 @@
 #include "stem/stem.h"
 
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/un.h>
 
 /* Reconnect attempts are rate-limited so a sidecar that is down costs one
@@ -100,7 +101,11 @@ int stem_ipc_ensure(void)
         return -1;
     g_next_try = now + IPC_RETRY_SEC;
 
-    fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    /* CLOEXEC: the deck forks helpers (edb_streamd, a shell for ping) that
+     * inherit every descriptor. A copy of this one in a child keeps the
+     * sidecar's end open after we close ours, so its read never returns and
+     * no reconnect is ever accepted. */
+    fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
     if (fd < 0)
         return -1;
 
@@ -162,11 +167,23 @@ static int ipc_write_all(const void *buf, size_t len)
         /* A zero return is not an error and leaves errno holding whatever an
          * earlier call left there. Only a negative return has an errno worth
          * printing. */
-        if (n == 0)
+        if (n == 0) {
             MDBG("stem_ipc: write %zu/%zu returned 0 (peer not draining)\n",
                  done, len);
-        else
-            MDBG("stem_ipc: write %zu/%zu failed errno=%d\n", done, len, errno);
+        } else {
+            /* What fd %d is at that moment: a number the deck reused for
+             * something else fails in ways a socket cannot. */
+            char link[64], target[96] = "?";
+            struct stat st;
+            int e = errno;
+
+            snprintf(link, sizeof(link), "/proc/self/fd/%d", g_fd);
+            if (readlink(link, target, sizeof(target) - 1) < 0)
+                snprintf(target, sizeof(target), "readlink errno=%d", errno);
+            MDBG("stem_ipc: write %zu/%zu failed errno=%d on fd %d -> %s mode=%#o\n",
+                 done, len, e, g_fd, target,
+                 fstat(g_fd, &st) == 0 ? (unsigned)st.st_mode : 0u);
+        }
         return -1;
     }
     return 0;

--- a/package/deck/mods/stem/job_loader.c
+++ b/package/deck/mods/stem/job_loader.c
@@ -85,6 +85,7 @@ static void loader_take_delivery(void)
     static uint32_t seen;
     char track[STEM_CACHE_PATH_MAX], h[STEM_CACHE_PATH_MAX], v[STEM_CACHE_PATH_MAX];
     float hg, vg;
+    int tmpfs;
     uint32_t gen = __atomic_load_n(&g_delivery.gen, __ATOMIC_ACQUIRE);
 
     if (gen == seen || (gen & 1u))
@@ -95,6 +96,7 @@ static void loader_take_delivery(void)
     snprintf(v, sizeof(v), "%s", g_delivery.v);
     hg = g_delivery.hg;
     vg = g_delivery.vg;
+    tmpfs = g_delivery.tmpfs;
 
     if (track_is_current(track)) {
         ui_publish(STEM_STAGE_LOADING, 0, 0);
@@ -108,11 +110,13 @@ static void loader_take_delivery(void)
         MDBG("stem_job: %s finished separating, but is no longer loaded --"
              " it is in the cache for when it is\n", track);
     }
-    /* The tmpfs copies are pure duplication from here: the media cache has the
-     * durable pair and publish has them in RAM. /dev/shm is guest RAM on a
-     * 3 GiB ceiling at ~170 MB a track. */
-    unlink(h);
-    unlink(v);
+    /* A pair still on tmpfs -- one the media would not take -- is pure
+     * duplication from here: publish has it in RAM. The media's own copy is the
+     * cache entry and stays. */
+    if (tmpfs) {
+        unlink(h);
+        unlink(v);
+    }
 }
 
 void * loader_main(void *arg)

--- a/package/deck/mods/stem/job_loader.c
+++ b/package/deck/mods/stem/job_loader.c
@@ -12,6 +12,66 @@
 #include "kit/popup.h"
 #include <pthread.h>
 
+/* A RETRY from the store is re-run every JOB_RETRY_SEC, this many times, and
+ * then the track is given up as FAILED: a pair that does not fit the deck's
+ * memory is not going to start fitting, and a probe against a track the deck
+ * will not size for us is not going to start succeeding. Reset on a track
+ * change. Loader thread only. */
+#define LOAD_RETRY_MAX 12
+static int g_load_retries;
+
+static int load_retry(const char *why)
+{
+    if (++g_load_retries > LOAD_RETRY_MAX) {
+        MDBG("stem_job: %s after %d attempts -> giving up on this track\n",
+             why, LOAD_RETRY_MAX);
+        ui_publish(STEM_STAGE_FAILED, 0, 0);
+        g_retry_at = 0;             /* or the probe runs once more and gives up again */
+        return 0;
+    }
+    MDBG("stem_job: %s, retrying in %d s (%d/%d)\n", why, JOB_RETRY_SEC,
+         g_load_retries, LOAD_RETRY_MAX);
+    job_retry_later();
+    return 1;
+}
+
+/* The decoder's length for a track, from the last probe that succeeded.
+ *
+ * A VBR MP3 is only sizeable through the deck's own tables, and those are held
+ * for the track the deck opened LAST. A track re-served from the page pool was
+ * not opened again, so its probe fails -- but its length has not changed, and
+ * with it the cache lookup still finds the pair. Loader thread only. */
+#define LEN_MEMO 16
+static struct {
+    char    path[STEM_CACHE_PATH_MAX];
+    int64_t frames;
+} g_len[LEN_MEMO];
+static int g_len_next;
+
+static int64_t len_known(const char *path)
+{
+    int i;
+
+    for (i = 0; i < LEN_MEMO; i++)
+        if (g_len[i].frames > 0 && strcmp(g_len[i].path, path) == 0)
+            return g_len[i].frames;
+    return -1;
+}
+
+static void len_remember(const char *path, int64_t frames)
+{
+    int i;
+
+    for (i = 0; i < LEN_MEMO; i++)
+        if (g_len[i].frames > 0 && strcmp(g_len[i].path, path) == 0) {
+            g_len[i].frames = frames;
+            return;
+        }
+    i = g_len_next++ % LEN_MEMO;
+    snprintf(g_len[i].path, sizeof(g_len[i].path), "%s", path);
+    g_len[i].frames = frames;
+}
+
 static int loader_publish(const char *h, float hg, const char *v, float vg)
 {
     int rc;
@@ -29,21 +89,34 @@ static void loader_serve(const char *path)
 {
     struct stem_cache_entry e;
     int64_t frames;
-    int rc;
+    int rc, remembered = 0;
 
     /* The DECODER's frame count, which is half the cache key: stems are aligned
      * to EP122's padded decode, so a firmware that pads differently must miss
      * rather than load something silently misaligned. */
     frames = stem_decode_pull(path, STEM_UPLOAD_RATE, NULL, NULL);
-    if (frames <= 0) {
-        MDBG("stem_job: length probe failed (%lld)\n", (long long)frames);
-        job_retry_later();
-        return;
+    if (frames > 0) {
+        len_remember(path, frames);
+    } else {
+        frames = len_known(path);
+        remembered = frames > 0;
+        if (!remembered) {
+            load_retry("length probe failed");
+            return;
+        }
+        MDBG("stem_job: length probe failed, using the earlier %lld\n",
+             (long long)frames);
     }
     if (!track_is_current(path))
         return;                     /* the DJ moved on while we probed */
 
     if (stem_cache_lookup(path, frames, &e) != 0) {
+        /* A remembered length finds a pair; it cannot decode a track the deck
+         * will not size, so there is nothing to upload. */
+        if (remembered) {
+            load_retry("no pair on the media and the track cannot be decoded");
+            return;
+        }
         /* A miss, and the ONLY route to the separator. */
         sep_request(path, frames);
         return;
@@ -57,9 +130,7 @@ static void loader_serve(const char *path)
     if (rc == STEM_PUBLISH_ABORT)
         return;                     /* the new track's generation drives us now */
     if (rc == STEM_PUBLISH_RETRY) {
-        MDBG("stem_job: cache hit not loadable yet, retrying in %d s\n",
-             JOB_RETRY_SEC);
-        job_retry_later();
+        load_retry("cache hit not loadable yet");
         return;
     }
     if (rc != STEM_PUBLISH_OK) {
@@ -79,18 +150,31 @@ static void loader_serve(const char *path)
     MDBG("stem_job: served from cache, no server needed\n");
 }
 
-/* A delivery from the separator, taken only if it is still wanted. */
+/* The delivery the loader has not consumed yet, if any. */
+static uint32_t g_delivery_seen;
+
+static int loader_delivery_pending(void)
+{
+    uint32_t gen = __atomic_load_n(&g_delivery.gen, __ATOMIC_ACQUIRE);
+
+    return gen != g_delivery_seen && !(gen & 1u);
+}
+
+/* A delivery from the separator, taken only if it is still wanted. A pair the
+ * store says RETRY to stays a pending delivery -- tmpfs copy included -- and is
+ * taken again when the retry falls due, rather than consumed with nothing
+ * scheduled. */
 static void loader_take_delivery(void)
 {
-    static uint32_t seen;
     char track[STEM_CACHE_PATH_MAX], h[STEM_CACHE_PATH_MAX], v[STEM_CACHE_PATH_MAX];
     float hg, vg;
     int tmpfs;
     uint32_t gen = __atomic_load_n(&g_delivery.gen, __ATOMIC_ACQUIRE);
 
-    if (gen == seen || (gen & 1u))
+    if (gen == g_delivery_seen || (gen & 1u))
         return;
-    seen = gen;
+    if (g_retry_at && job_now_sec() < g_retry_at)
+        return;                     /* a RETRY is waiting its turn */
     snprintf(track, sizeof(track), "%s", g_delivery.track);
     snprintf(h, sizeof(h), "%s", g_delivery.h);
     snprintf(v, sizeof(v), "%s", g_delivery.v);
@@ -99,9 +183,14 @@ static void loader_take_delivery(void)
     tmpfs = g_delivery.tmpfs;
 
     if (track_is_current(track)) {
+        int rc;
+
         ui_publish(STEM_STAGE_LOADING, 0, 0);
-        if (loader_publish(h, hg, v, vg) == STEM_PUBLISH_OK &&
-            track_is_current(track)) {
+        rc = loader_publish(h, hg, v, vg);
+        if (rc == STEM_PUBLISH_RETRY &&
+            load_retry("the separated pair cannot be loaded yet"))
+            return;                 /* still pending */
+        if (rc == STEM_PUBLISH_OK && track_is_current(track)) {
             __atomic_store_n(&g_stem_ready, 1, __ATOMIC_RELEASE);
             ui_publish(STEM_STAGE_DONE, 100, 0);
             wave_stems_track_ready(track);
@@ -110,9 +199,10 @@ static void loader_take_delivery(void)
         MDBG("stem_job: %s finished separating, but is no longer loaded --"
              " it is in the cache for when it is\n", track);
     }
+    g_delivery_seen = gen;
     /* A pair still on tmpfs -- one the media would not take -- is pure
-     * duplication from here: publish has it in RAM. The media's own copy is the
-     * cache entry and stays. */
+     * duplication from here: publish has it in RAM, or gave up on it. The
+     * media's own copy is the cache entry and stays. */
     if (tmpfs) {
         unlink(h);
         unlink(v);
@@ -139,6 +229,7 @@ void * loader_main(void *arg)
             memset(g_arrived, 0, sizeof(g_arrived));
             ui_publish(STEM_STAGE_IDLE, 0, 0);
             g_retry_at = 0;
+            g_load_retries = 0;
         }
 
         loader_take_delivery();
@@ -146,8 +237,10 @@ void * loader_main(void *arg)
         /* A scheduled retry OUTRANKS `served`. Requiring both meant the flag
          * won every time -- it is set the moment the separator is asked, which
          * is before anything can fail -- so job_failed's reschedule was never
-         * acted on and a job that died on the wire stayed dead. */
-        if (g_stems_on && g_cur_path[0] &&
+         * acted on and a job that died on the wire stayed dead. A pending
+         * delivery owns the retry it scheduled; the probe would only find the
+         * same pair on the media and load it twice. */
+        if (!loader_delivery_pending() && g_stems_on && g_cur_path[0] &&
             (g_retry_at ? job_now_sec() >= g_retry_at : !served)) {
             char path[STEM_CACHE_PATH_MAX];
 

--- a/package/deck/mods/stem/job_separator.c
+++ b/package/deck/mods/stem/job_separator.c
@@ -13,7 +13,7 @@
 #include <pthread.h>
 
 static void sep_deliver(const char *track, const char *h, float hg,
-                        const char *v, float vg)
+                        const char *v, float vg, int tmpfs)
 {
     uint32_t gen = g_delivery.gen;
 
@@ -24,7 +24,7 @@ static void sep_deliver(const char *track, const char *h, float hg,
     snprintf(g_delivery.v, sizeof(g_delivery.v), "%s", v);
     g_delivery.hg = hg;
     g_delivery.vg = vg;
-    g_delivery.tmpfs = 1;
+    g_delivery.tmpfs = tmpfs;
     __atomic_thread_fence(__ATOMIC_RELEASE);
     __atomic_store_n(&g_delivery.gen, gen + 2, __ATOMIC_RELAXED);
     MDBG("stem_job: separated %s -> handed to the loader\n", track);
@@ -101,7 +101,8 @@ int handle_frame(uint32_t type, const void *buf, uint32_t len)
     }
     case STEM_MSG_STEM_READY: {
         const struct stem_ready *r = buf;
-        int part;
+        struct stem_cache_entry e;
+        int part, stored;
 
         if (len < sizeof(*r) || len < sizeof(*r) + r->path_len)
             return 0;
@@ -126,19 +127,32 @@ int handle_frame(uint32_t type, const void *buf, uint32_t len)
          * what makes a separation the DJ switched away from still worth having:
          * the entry lands whether or not anyone is waiting for it. The store
          * rule decides whether this volume may hold it at all. */
-        stem_cache_store(g_job_path, g_job_frames,
-                         g_arrived[STEM_PART_HARMONICS].path,
-                         g_arrived[STEM_PART_HARMONICS].gain,
-                         g_arrived[STEM_PART_VOCALS].path,
-                         g_arrived[STEM_PART_VOCALS].gain);
+        stored = stem_cache_store(g_job_path, g_job_frames,
+                                  g_arrived[STEM_PART_HARMONICS].path,
+                                  g_arrived[STEM_PART_HARMONICS].gain,
+                                  g_arrived[STEM_PART_VOCALS].path,
+                                  g_arrived[STEM_PART_VOCALS].gain) == 0;
 
         /* Then hand the loader the paths and let it decide whether they are
-         * still wanted. Nothing here touches g_set. */
-        sep_deliver(g_job_path,
-                    g_arrived[STEM_PART_HARMONICS].path,
-                    g_arrived[STEM_PART_HARMONICS].gain,
-                    g_arrived[STEM_PART_VOCALS].path,
-                    g_arrived[STEM_PART_VOCALS].gain);
+         * still wanted. Nothing here touches g_set.
+         *
+         * THE MEDIA'S COPY, once there is one, and the tmpfs pair goes first.
+         * /dev/shm is RAM, and a 9-minute pair is 100 MB of it sitting there
+         * for the whole of a 415 MB load -- the difference between the pair
+         * fitting and the kernel killing EP122. The loader reads the media at
+         * the speed a cache hit already does. */
+        if (stored && stem_cache_lookup(g_job_path, g_job_frames, &e) == 0) {
+            unlink(g_arrived[STEM_PART_HARMONICS].path);
+            unlink(g_arrived[STEM_PART_VOCALS].path);
+            sep_deliver(g_job_path, e.harmonics_path, e.harmonics_gain,
+                        e.vocals_path, e.vocals_gain, 0);
+        } else {
+            sep_deliver(g_job_path,
+                        g_arrived[STEM_PART_HARMONICS].path,
+                        g_arrived[STEM_PART_HARMONICS].gain,
+                        g_arrived[STEM_PART_VOCALS].path,
+                        g_arrived[STEM_PART_VOCALS].gain, 1);
+        }
         return 1;
     }
     case STEM_MSG_JOB_FAILED: {

--- a/package/deck/mods/stem/store.c
+++ b/package/deck/mods/stem/store.c
@@ -210,16 +210,16 @@ static int fill_chunk(const float *pcm, int64_t frames, void *user)
 static uint64_t mem_available(void)
 {
     char line[96];
-    uint64_t kb = 0;
+    unsigned long long kb = 0;
     FILE *fp = fopen("/proc/meminfo", "r");
 
     if (!fp)
         return 0;
     while (fgets(line, sizeof(line), fp))
-        if (sscanf(line, "MemAvailable: %llu kB", (unsigned long long *)&kb) == 1)
+        if (sscanf(line, "MemAvailable: %llu kB", &kb) == 1)
             break;
     fclose(fp);
-    return kb * 1024;
+    return (uint64_t)kb * 1024;
 }
 
 static int64_t load_one(struct stem_buf *slot, const char *path, int rate,
@@ -227,7 +227,6 @@ static int64_t load_one(struct stem_buf *slot, const char *path, int rate,
 {
     struct fill_ctx ctx;
     int64_t len, got;
-    uint64_t need, avail;
 
     len = stem_decode_pull(path, rate, NULL, NULL);
     if (len <= 0) {
@@ -235,28 +234,14 @@ static int64_t load_one(struct stem_buf *slot, const char *path, int rate,
         MDBG("stem_store: %s: length probe failed (%lld)\n", path, (long long)len);
         return STEM_PUBLISH_BAD;
     }
-    /* THE PAIR, not this part: both load side by side, so each asks for both.
-     * Asked up front because a malloc that cannot be honoured does not fail on
-     * this kernel -- it overcommits, and kills EP122 when the pages are touched
-     * -- and a deck that restarts mid-set is worse than a track without stems.
-     * RETRY, like the malloc below: the shortage may be the deck's own load
-     * still settling. */
-    need = 2 * (uint64_t)len * 2 * sizeof(int16_t) + LOAD_HEADROOM;
-    avail = mem_available();
-    if (avail && need > avail) {
-        MDBG("stem_store: %s: the pair needs %llu MB with headroom, %llu MB"
-             " available -> not loading\n", path,
-             (unsigned long long)(need >> 20), (unsigned long long)(avail >> 20));
-        stem_progress_set(STEM_STAGE_IDLE, 0);
-        return STEM_PUBLISH_RETRY;
-    }
     slot->pcm = malloc((size_t)len * 2 * sizeof(int16_t));
     if (!slot->pcm) {
         /* Us, not the file. Saying BAD here would condemn a good cache entry
-         * over a momentary shortage and re-separate the track. */
+         * over a momentary shortage and re-separate the track. The stage stays
+         * LOADING through the retry: IDLE reads as "nothing asked", and offline
+         * that is the warning badge. */
         MDBG("stem_store: %s: out of memory for %lld frames (%lld MB)\n",
              path, (long long)len, (long long)(len * 4 / (1024 * 1024)));
-        stem_progress_set(STEM_STAGE_IDLE, 0);
         return STEM_PUBLISH_RETRY;
     }
     ctx.pcm = slot->pcm;
@@ -405,11 +390,32 @@ static void *load_thread_fn(void *p)
     return NULL;
 }
 
+/* Whether the deck can hold a pair of `len` frames at the pool rate, with
+ * LOAD_HEADROOM to spare. Asked before either part is allocated: a malloc that
+ * cannot be honoured does not fail on this kernel -- it overcommits, and kills
+ * EP122 when the pages are touched -- and a deck that restarts mid-set is worse
+ * than a track without stems. Once, for the pair: the two parts load side by
+ * side, and a part asking after its sibling has touched its buffer would refuse
+ * a pair that fits. */
+static int pair_fits(const char *path, int64_t len)
+{
+    uint64_t need = 2 * (uint64_t)len * 2 * sizeof(int16_t) + LOAD_HEADROOM;
+    uint64_t avail = mem_available();
+
+    if (!avail || need <= avail)
+        return 1;
+    MDBG("stem_store: %s: the pair needs %llu MB with headroom, %llu MB"
+         " available -> not loading\n", path,
+         (unsigned long long)(need >> 20), (unsigned long long)(avail >> 20));
+    return 0;
+}
+
 /* Build a set from two already-written files and publish it. Worker thread. */
 int stem_store_publish(const char *harmonics_path, float harmonics_gain,
                        const char *vocals_path, float vocals_gain)
 {
     int rate;
+    int64_t len;
     struct stem_set *set;
 
     /* Said before either wait, not after: both of them block, and a bar frozen on
@@ -430,6 +436,12 @@ int stem_store_publish(const char *harmonics_path, float harmonics_gain,
      * back in a few seconds, by which time the load it was racing is over. */
     if (!wait_for_deck())
         return stem_job_load_wanted() ? STEM_PUBLISH_RETRY : STEM_PUBLISH_ABORT;
+    /* The shortage may be the deck's own load still settling: RETRY, not BAD.
+     * A file the probe cannot size is left to load_one, which knows what to
+     * say about it. */
+    len = stem_decode_pull(harmonics_path, rate, NULL, NULL);
+    if (len > 0 && !pair_fits(harmonics_path, len))
+        return STEM_PUBLISH_RETRY;
     set = calloc(1, sizeof(*set));
     if (!set)
         return STEM_PUBLISH_RETRY;

--- a/package/deck/mods/stem/store.c
+++ b/package/deck/mods/stem/store.c
@@ -201,11 +201,33 @@ static int fill_chunk(const float *pcm, int64_t frames, void *user)
  * whole load over a tail nobody hears. decode.c logs where a stream ended; a
  * genuinely unreadable stem stops four orders of magnitude short and is obvious
  * in that one line. */
+/* What the deck keeps for itself while a pair is resident: its page pool,
+ * the waveforms, the browser. Measured on the emulator: EP122 idles at
+ * ~490 MB and the kernel killed it at 1020 MB with a 415 MB pair in. */
+#define LOAD_HEADROOM   (128u * 1024 * 1024)
+
+/* MemAvailable, or 0 when it cannot be read. */
+static uint64_t mem_available(void)
+{
+    char line[96];
+    uint64_t kb = 0;
+    FILE *fp = fopen("/proc/meminfo", "r");
+
+    if (!fp)
+        return 0;
+    while (fgets(line, sizeof(line), fp))
+        if (sscanf(line, "MemAvailable: %llu kB", (unsigned long long *)&kb) == 1)
+            break;
+    fclose(fp);
+    return kb * 1024;
+}
+
 static int64_t load_one(struct stem_buf *slot, const char *path, int rate,
                         float gain, int report)
 {
     struct fill_ctx ctx;
     int64_t len, got;
+    uint64_t need, avail;
 
     len = stem_decode_pull(path, rate, NULL, NULL);
     if (len <= 0) {
@@ -213,12 +235,28 @@ static int64_t load_one(struct stem_buf *slot, const char *path, int rate,
         MDBG("stem_store: %s: length probe failed (%lld)\n", path, (long long)len);
         return STEM_PUBLISH_BAD;
     }
+    /* THE PAIR, not this part: both load side by side, so each asks for both.
+     * Asked up front because a malloc that cannot be honoured does not fail on
+     * this kernel -- it overcommits, and kills EP122 when the pages are touched
+     * -- and a deck that restarts mid-set is worse than a track without stems.
+     * RETRY, like the malloc below: the shortage may be the deck's own load
+     * still settling. */
+    need = 2 * (uint64_t)len * 2 * sizeof(int16_t) + LOAD_HEADROOM;
+    avail = mem_available();
+    if (avail && need > avail) {
+        MDBG("stem_store: %s: the pair needs %llu MB with headroom, %llu MB"
+             " available -> not loading\n", path,
+             (unsigned long long)(need >> 20), (unsigned long long)(avail >> 20));
+        stem_progress_set(STEM_STAGE_IDLE, 0);
+        return STEM_PUBLISH_RETRY;
+    }
     slot->pcm = malloc((size_t)len * 2 * sizeof(int16_t));
     if (!slot->pcm) {
         /* Us, not the file. Saying BAD here would condemn a good cache entry
          * over a momentary shortage and re-separate the track. */
         MDBG("stem_store: %s: out of memory for %lld frames (%lld MB)\n",
              path, (long long)len, (long long)(len * 4 / (1024 * 1024)));
+        stem_progress_set(STEM_STAGE_IDLE, 0);
         return STEM_PUBLISH_RETRY;
     }
     ctx.pcm = slot->pcm;

--- a/package/deck/mods/stem/ui/hooks.c
+++ b/package/deck/mods/stem/ui/hooks.c
@@ -87,6 +87,12 @@ int stems_available(void)
         return 1;
     if (!stem_ui_read(&st) || !st.status_seen)
         return 1;                           /* nothing asked yet: say nothing */
+    /* A pair coming off the media needs no server: the stems are on the way
+     * whatever the sidecar thinks of the network, and for a long track that leg
+     * runs a minute. Only the OFF-MEDIA load; a separation's own LOADING leg
+     * belongs to the server test below. */
+    if (st.stage == STEM_STAGE_LOADING && !st.via_server)
+        return 1;
     /* A SERVER THE SIDECAR HAS CALLED UNUSABLE IS THE ANSWER, whatever stage a
      * job happens to be in. This test used to sit below the one after it, and
      * that ordering broke the moment failures started being retried: every five


### PR DESCRIPTION
Closes #4
Closes #5
Closes #6

Three commits, one per issue:

- **#4** A failed reader open no longer binds a new track to the previous track's path (consume-once fresh-track flag). The deck's JUCE fallback reader, which is what plays 32-bit float WAV, is hooked as an eighth reader, and a successful open supersedes a failed capture.
- **#5** The deck's own seekTable/frameInfo are handed back to createReaderFor, which is what lets a VBR MP3 be sized; the length probe no longer returns −1. An untested PVBR fallback was dropped rather than shipped.
- **#6** A pair loading off the media no longer shows the warn badge. A pair that will not fit in MemAvailable is retried instead of loaded (the 9-minute case: 415 MB resident). The tmpfs copy is unlinked before the media copy is loaded, the cache lookup tries every separation-id directory so a stick written by one model plays on a deck using another, and docs/stems.md states the frame-count rule an offline writer must match.

Tested with a generated MP3 set (LAME −V2/−V0, ABR, ffmpeg −q2, no-Xing, CBR), a float WAV, a 9-minute track, a second player, USB eject, and stemd offline. Guest RAM was raised to 3 GiB for the 9-minute case.

---

**After review** (two more commits, both emu-tested):

- A delivery the store answers RETRY to is held and retaken every 5 s instead of consumed with nothing scheduled; every RETRY, from a delivery or a cache hit, stops after 12 attempts and the track is FAILED. The stage stays LOADING across the wait (IDLE offline blinked the badge). The pair-size check runs once before either part allocates. A re-served track that cannot be re-probed is looked up with the length remembered from its last good probe, so a cached VBR MP3 is found after NEXT/BACK. The fresh-track flag is spent on a reload of an evicted track. `docs/stems.md` states the frame rule as container count, then round up, at 44.1 kHz.
- The sidecar socket is `SOCK_CLOEXEC`. The deck forks helpers (edb_streamd, a shell for ping) that inherit descriptors, and a child's copy kept the sidecar's end open after the shim closed its own, wedging it until restart. Applies to real hardware.

Tested cache-hit and delivery retry paths with an impossible headroom (12 refusals, FAILED, tmpfs clean), VBR next-back served from cache, a fresh 9-minute separation.