### PR TITLE
fix: stem job on a paused load, and the MOD SETTINGS address row

### DIFF
--- a/package/deck/docs/mods.md
+++ b/package/deck/docs/mods.md
@@ -713,8 +713,9 @@ rows below it down rather than renumbering anything.
 
 Both ways that can go wrong are a developer's, since the mods are statically linked:
 two siblings claiming one `idx` disables every row and the Ver-tap says so on the
-glass instead of arming, and more live rows than the eight-row list can show
-(`KIT_MENU_MAX_ROWS`) drops the surplus with a log line naming the first one. Neither
+glass instead of arming, and more live rows than the list can show (nine when the
+overlay could grow it to ten rows, seven when it could not; `KIT_MENU_MAX_ROWS` and
+`kit_menu_set_shown`) drops the surplus with a log line naming the first one. Neither
 is silent.
 
 The right pane is the deck's, borrowed. What the mod supplies is the answer to how

--- a/package/deck/mods/core/ep122_syms.h
+++ b/package/deck/mods/core/ep122_syms.h
@@ -49,6 +49,7 @@ enum ep122_sym {
     EP122_PCM_STRETCH,
     EP122_PCM_PREVIEW,
     EP122_TSMGR,
+    EP122_PCM_LOADRESULT_TASK,
     EP122_SRC,
     EP122_AUDIO_READER_FACTORY,
     EP122_READER_FLAC,
@@ -131,6 +132,7 @@ enum ep122_sym {
     EP122_PCM_SIMPLE_READ,
     EP122_PCM_PAGEBUF_READ,
     EP122_PCM_STRETCH_READ,
+    EP122_PCM_LOADRESULT_RUN,
     EP122_PCM_PREVIEW_READ,
     EP122_TSMGR_OPERATE,
     EP122_TSMGR_SETSOURCE,
@@ -286,6 +288,7 @@ static const struct ep122_vt_spec {
     { EP122_PCM_STRETCH, "N11time_domain26ReadableTimeStretchAdapterE", NULL },   /* 0x1f3c728 */
     { EP122_PCM_PREVIEW, "N14preview_player17RealtimeSRCBufferE", NULL },   /* 0x201b5e8 */
     { EP122_TSMGR, "N11time_domain26CascadedTimeStretchManagerE", NULL },   /* 0x1f3ce48 */
+    { EP122_PCM_LOADRESULT_TASK, "*N4meow16AsyncTaskBoxBase9AsyncTaskIZN9dj_player24PcmBufferFunctionHandler12onLoadResultEN6pcmbuf19ILoadResultListener6ResultERKN7trackid7TrackIDERKNS_18RefCountedObjExPtrINS4_10SourceInfoEEEN12audio_format15AudioFormatKindEEUlvE_EE", NULL },   /* 0x1ff7b30 */
     { EP122_SRC, "N12audio_format19SampleRateConverterE", NULL },   /* 0x1f159e0 */
     { EP122_AUDIO_READER_FACTORY, "N12audio_format18AudioReaderFactoryE", NULL },   /* 0x1f138d8 */
     { EP122_READER_FLAC, "N12audio_format12FileReadFlacE", NULL },   /* 0x1f14d18 */
@@ -337,7 +340,7 @@ static const struct ep122_vt_spec {
     { EP122_GRIDBTN_SHIFT, "N3gui18grid_adjust_button15ShiftGridButtonE", NULL },   /* 0x20f69d0 */
     { EP122_GRIDBTN_RESET, "N3gui18grid_adjust_button11ResetButtonE", NULL },   /* 0x20f7a30 */
 };
-#define EP122_N_VT 83
+#define EP122_N_VT 84
 
 /* ---- virtuals: whatever the slot holds IS the implementation ---- */
 static const struct ep122_slot_spec {
@@ -382,6 +385,7 @@ static const struct ep122_slot_spec {
     { EP122_PCM_SIMPLE_READ, EP122_PCM_SIMPLE, 0x10 },   /* 0xb12178 */
     { EP122_PCM_PAGEBUF_READ, EP122_PCM_PAGEBUF, 0x10 },   /* 0x6ab128 */
     { EP122_PCM_STRETCH_READ, EP122_PCM_STRETCH, 0x10 },   /* 0xaea7f8 */
+    { EP122_PCM_LOADRESULT_RUN, EP122_PCM_LOADRESULT_TASK, 0x10 },   /* 0x107e3d8 */
     { EP122_PCM_PREVIEW_READ, EP122_PCM_PREVIEW, 0x10 },   /* 0x11767f8 */
     { EP122_TSMGR_OPERATE, EP122_TSMGR, 0x98 },   /* 0xaecfc0 */
     { EP122_TSMGR_SETSOURCE, EP122_TSMGR, 0x38 },   /* 0xaec298 */
@@ -411,7 +415,7 @@ static const struct ep122_slot_spec {
     { EP122_HUI_MC_UPDATE, EP122_HUI_MULTICOLOR, 0x10 },   /* 0x1803ae0 */
     { EP122_SRV_MSG_RUN, EP122_SRV_MSG_TASK, 0x10 },   /* 0xb3c9d0 */
 };
-#define EP122_N_SLOT 65
+#define EP122_N_SLOT 66
 
 /* ---- free functions: masked aarch64 signatures ---- */
 #define EP122_SIG_INSNS_MAX 96
@@ -616,6 +620,7 @@ static const char *const k_ep122_sym_name[] = {
     "PCM_STRETCH",
     "PCM_PREVIEW",
     "TSMGR",
+    "PCM_LOADRESULT_TASK",
     "SRC",
     "AUDIO_READER_FACTORY",
     "READER_FLAC",
@@ -698,6 +703,7 @@ static const char *const k_ep122_sym_name[] = {
     "PCM_SIMPLE_READ",
     "PCM_PAGEBUF_READ",
     "PCM_STRETCH_READ",
+    "PCM_LOADRESULT_RUN",
     "PCM_PREVIEW_READ",
     "TSMGR_OPERATE",
     "TSMGR_SETSOURCE",

--- a/package/deck/mods/core/ep122_syms.spec
+++ b/package/deck/mods/core/ep122_syms.spec
@@ -138,6 +138,11 @@ vtable PCM_PAGEBUF        class=N6pcmbuf7pagebuf10PageBufferINS0_23DefaultPageSt
 vtable PCM_STRETCH        class=N11time_domain26ReadableTimeStretchAdapterE
 vtable PCM_PREVIEW        class=N14preview_player17RealtimeSRCBufferE
 vtable TSMGR              class=N11time_domain26CascadedTimeStretchManagerE
+# The deck's own "the track is in the pool" event: onLoadResult posts this task
+# with the load's SourceId at closure+0x18/+0x20 (the same 16 bytes the pool
+# reads carry) and its Result at +0x30. Fires whether or not anything plays,
+# which the reads do not on a deck loaded and left at 0:00.
+vtable PCM_LOADRESULT_TASK class=*N4meow16AsyncTaskBoxBase9AsyncTaskIZN9dj_player24PcmBufferFunctionHandler12onLoadResultEN6pcmbuf19ILoadResultListener6ResultERKN7trackid7TrackIDERKNS_18RefCountedObjExPtrINS4_10SourceInfoEEEN12audio_format15AudioFormatKindEEUlvE_EE
 
 # --- mods/stem/decode.c ---
 vtable SRC                class=N12audio_format19SampleRateConverterE
@@ -350,6 +355,7 @@ slot PCM_SEQ_READ           vtable=PCM_SEQ            off=0x10
 slot PCM_SIMPLE_READ        vtable=PCM_SIMPLE         off=0x10
 slot PCM_PAGEBUF_READ       vtable=PCM_PAGEBUF        off=0x10
 slot PCM_STRETCH_READ       vtable=PCM_STRETCH        off=0x10
+slot PCM_LOADRESULT_RUN     vtable=PCM_LOADRESULT_TASK off=0x10
 slot PCM_PREVIEW_READ       vtable=PCM_PREVIEW        off=0x10
 slot TSMGR_OPERATE          vtable=TSMGR              off=0x98
 slot TSMGR_SETSOURCE        vtable=TSMGR              off=0x38

--- a/package/deck/mods/kit/menu.c
+++ b/package/deck/mods/kit/menu.c
@@ -18,6 +18,7 @@ static int                   g_ndef;
 static const struct kit_row *g_live[KIT_MENU_MAX_ROWS];
 static int                   g_nlive;
 static int                   g_overflow;      /* the flatten in progress hit the ceiling */
+static int                   g_shown = KIT_MENU_MAX_ROWS;   /* rows the list can show */
 
 static char g_problem[96];                    /* empty while the row list is usable */
 static int  g_checked = -1;                   /* the g_ndef g_problem was decided against */
@@ -146,7 +147,12 @@ static void dropped(const struct kit_row *r)
     if (told == r->label) return;
     told = r->label;
     KMSG("%d rows fit; \"%s\" and anything under or after it is not shown\n",
-         KIT_MENU_MAX_ROWS, r->label);
+         g_shown, r->label);
+}
+
+void kit_menu_set_shown(int n)
+{
+    g_shown = n < 1 ? 1 : n > KIT_MENU_MAX_ROWS ? KIT_MENU_MAX_ROWS : n;
 }
 
 /* One level, in idx order, recursing into each revealed row. A row's children
@@ -176,7 +182,7 @@ static void emit(const struct kit_row *parent)
         last = next->idx;
 
         if (!revealed(next)) continue;
-        if (g_nlive >= KIT_MENU_MAX_ROWS) {
+        if (g_nlive >= g_shown) {
             dropped(next);
             return;
         }

--- a/package/deck/mods/kit/menu.h
+++ b/package/deck/mods/kit/menu.h
@@ -75,15 +75,16 @@ struct kit_row {
 #define KIT_IDX_STEMS  30
 
 /* How many rows can be SEEN at once, and therefore how many exist as far as a
- * DJ is concerned. The overlay reports a fixed 8 rows to JUCE -- the stock DJ
- * SETTING count, so the viewport fills exactly as stock fills it and no
- * scrollbar can appear -- and row 0 is the "MOD SETTINGS" title.
+ * DJ is concerned. The overlay sizes the list for MOD_ROWS_VISIBLE rows -- what
+ * the UTILITY panel has room for, with no scrollbar -- and row 0 is the
+ * "MOD SETTINGS" title, so this is one less. Every mod on with STEMS set to
+ * MANUAL is eight rows.
  *
  * The live count is dynamic (revealing children grows it), so this is enforced
  * when the list is flattened rather than at registration: the overflow is
  * logged and the surplus dropped. A row that is silently invisible and
  * unreachable is the failure this exists to prevent. */
-#define KIT_MENU_MAX_ROWS 7
+#define KIT_MENU_MAX_ROWS 9
 
 /* The longest buffer a TEXT row may hand over. The overlay keeps the pre-edit
  * value in a buffer of its own, which has to be sized for any row. */

--- a/package/deck/mods/kit/menu.h
+++ b/package/deck/mods/kit/menu.h
@@ -83,8 +83,14 @@ struct kit_row {
  * The live count is dynamic (revealing children grows it), so this is enforced
  * when the list is flattened rather than at registration: the overflow is
  * logged and the surplus dropped. A row that is silently invisible and
- * unreachable is the failure this exists to prevent. */
+ * unreachable is the failure this exists to prevent. The ceiling in force is
+ * whatever the overlay could size the list for (kit_menu_set_shown): a list it
+ * could not grow shows seven, and the eighth is dropped with the same log line
+ * rather than drawn nowhere. */
 #define KIT_MENU_MAX_ROWS 9
+
+/* The rows the list can show right now, 1..KIT_MENU_MAX_ROWS. */
+void kit_menu_set_shown(int n);                         /* [message] */
 
 /* The longest buffer a TEXT row may hand over. The overlay keeps the pre-edit
  * value in a buffer of its own, which has to be sized for any row. */

--- a/package/deck/mods/menu/editor.c
+++ b/package/deck/mods/menu/editor.c
@@ -164,7 +164,7 @@ static void mod_kbd_move_editor(uintptr_t editor, int row)
     if (b[2] <= 0 || b[3] <= 0 || b[3] > 4 * MOD_ROW_H) return;   /* not a row-sized editor */
     if (stock_y < 0) stock_y = b[1];
     ((void (*)(void *, int, int))FN_SET_TOPLEFT)
-        ((void *)editor, b[0], stock_y + (row - KBD_STOCK_ROW) * MOD_ROW_H);
+        ((void *)editor, b[0], stock_y + (row - KBD_STOCK_ROW) * menu_list_row_h());
 }
 
 /* Clear the right pane for the duration of the edit, the way the stock text setting does:

--- a/package/deck/mods/menu/editor.c
+++ b/package/deck/mods/menu/editor.c
@@ -202,7 +202,16 @@ void menu_kbd_open(const struct kit_row *r)
     g_kbd_up = 1;
     g_kbd_row = r;
     mod_editor_show_text(r->text);
-    mod_kbd_move_editor(ours, menu_g_setting_row);
+    {
+        /* A row under the keyboard is scrolled up first; the editor then sits on
+         * the slot it lands in. The scroll rebuilds the right pane, hence the
+         * second hide. */
+        int shown = menu_list_fit_above_kbd(
+            menu_view_ptr(menu_g_view, VIEW_DJLIST_OFF), menu_g_setting_row);
+
+        menu_pane_show(menu_g_view, 0);
+        mod_kbd_move_editor(ours, shown);
+    }
     juce_comp_set_visible(ours, 1);
     ((void (*)(void *))FN_EDITOR_FOCUS)((void *)ours);
 
@@ -230,6 +239,10 @@ void menu_kbd_close(void)
     juce_comp_set_visible(g_editor, 0);
     menu_pane_show(menu_g_view, 1);
     ((void (*)(void *))FN_KBD_HIDE)((void *)menu_g_view);
+    /* Back to full height if the open cut it down for the keyboard. The whole
+     * refresh, not just the resize: a list that was scrolled and overflowing
+     * keeps its scroll indicators and offset until updateContent re-lays it out. */
+    menu_refresh_djlist((void *)menu_g_view);
 
     if (!r || strcmp(g_kbd_orig, r->text) == 0) {
         MDBG("keyboard: closed, value unchanged\n");

--- a/package/deck/mods/menu/hooks.c
+++ b/package/deck/mods/menu/hooks.c
@@ -15,9 +15,10 @@
 static int32_t mod_numrows(void *self)
 {
     /* Collapse to just the mod rows in mod mode: JUCE then clamps the selection
-     * to those rows (no plugging), and the count change (8->N) is what makes
-     * updateContent actually re-layout + repaint. */
-    if (menu_g_mod_mode) return MOD_ROWS_VISIBLE;
+     * to those rows (no plugging), and the count change is what makes
+     * updateContent actually re-layout + repaint. The count is whatever
+     * menu_list_fit made room for, so the list never scrolls. */
+    if (menu_g_mod_mode) return menu_g_list_rows;
     return ((numrows_t)menu_g_orig_numrows)(self);
 }
 

--- a/package/deck/mods/menu/hooks.c
+++ b/package/deck/mods/menu/hooks.c
@@ -17,7 +17,8 @@ static int32_t mod_numrows(void *self)
     /* Collapse to just the mod rows in mod mode: JUCE then clamps the selection
      * to those rows (no plugging), and the count change is what makes
      * updateContent actually re-layout + repaint. The count is whatever
-     * menu_list_fit made room for, so the list never scrolls. */
+     * menu_list_fit made room for, so the list only scrolls while the
+     * keyboard has cut it down (menu_list_fit_above_kbd). */
     if (menu_g_mod_mode) return menu_g_list_rows;
     return ((numrows_t)menu_g_orig_numrows)(self);
 }

--- a/package/deck/mods/menu/internal.h
+++ b/package/deck/mods/menu/internal.h
@@ -425,6 +425,7 @@ void      menu_pane_show(uintptr_t view, int visible);
 void    menu_apply_value(int row, int focus_pane, const char *src);
 void    menu_pane_fit(uintptr_t rlist, int rows);
 void    menu_list_fit(uintptr_t list, int armed);
+int     menu_list_row_h(void);          /* measured, MOD_ROW_H until it is */
 int     menu_list_fit_above_kbd(uintptr_t list, int row);
 void    menu_pane_labels(uintptr_t view, uintptr_t rmodel, const struct kit_row *r);
 void    menu_force_right_pane_sel(uintptr_t view, int sel_row);

--- a/package/deck/mods/menu/internal.h
+++ b/package/deck/mods/menu/internal.h
@@ -327,6 +327,7 @@ extern uintptr_t menu_g_orig_numrows, menu_g_orig_paintcell, menu_g_orig_mousedo
                  menu_g_orig_rnumrows;
 extern int       menu_g_render_ok;   /* JUCE render primitives verified at install */
 extern int       menu_g_mod_mode;    /* 1 while the mod overlay is drawing over DJ SETTING */
+extern int       menu_g_list_rows;   /* rows the DJ SETTING list is currently sized for */
 extern uintptr_t menu_g_model;       /* DJSettingTableModel, captured in paintCell */
 extern uintptr_t menu_g_view;        /* UTILITY view, captured from the hooks that get it */
 extern int       menu_g_bouncing;    /* re-entry guard for the title-row bounce */
@@ -347,13 +348,33 @@ extern uintptr_t menu_g_orig_kbdkey; /* the view's own keyboard IListener callba
 #define MOD_ROW_TITLE  0
 #define MOD_ROW_FIRST  1                     /* first selectable row (title is a label) */
 
-/* Rows reported to JUCE while armed. Only the live ones carry content; the rest get
- * the stock row background + divider. Equal to the stock count, so the viewport
- * fills as DJ SETTING fills it and no scrollbar appears. The title takes one, which
- * is what leaves KIT_MENU_MAX_ROWS for settings. */
-#define MOD_ROWS_VISIBLE 8
+/* Rows reported to JUCE while armed, and the height the list is given to show
+ * them without a scrollbar. Stock sizes the DJ SETTING list for eight rows and
+ * leaves the panel below it blank; the overlay grows the list into that blank
+ * (menu_list_fit) and reports this many, the title taking one of them. Ten is
+ * what the panel has room for: its row area ends about 620 px down, and the
+ * list starts at 92, so a tenth 50 px row ends at 592. Only the live rows carry
+ * content; the rest get the stock row background + divider. */
+#define MOD_ROWS_VISIBLE 10
 _Static_assert(MOD_ROWS_VISIBLE - MOD_ROW_FIRST == KIT_MENU_MAX_ROWS,
                "the kit's row capacity must be what this list can show");
+
+/* Rows the stock DJ SETTING list is sized for: the unit menu_list_fit measures
+ * the row height from, and what is reported while the list is stock-sized. */
+#define MOD_LIST_ROWS_STOCK 8
+
+/* Where the panel's row area ends. Below it is the waveform strip, and a list
+ * that ran into that would be worse than one that scrolls. */
+#define MOD_LIST_BOTTOM 620
+
+/* More than a scrollbar's thickness: what the list is grown past its target by,
+ * for one call, so JUCE drops both scrollbars -- see menu_list_fit. */
+#define MOD_LIST_GROW_SLACK 24
+
+/* The software keyboard's top edge: it rises from the bottom of the screen to
+ * the divider under the seventh row, so a text row below that is edited out of
+ * sight unless the list is scrolled -- see menu_list_fit_above_kbd. */
+#define MOD_KBD_TOP 444
 
 /* Bounds the stack array that builds the value list. */
 #ifndef MOD_ROW_VALUES_MAX
@@ -403,6 +424,8 @@ void      menu_pane_show(uintptr_t view, int visible);
 
 void    menu_apply_value(int row, int focus_pane, const char *src);
 void    menu_pane_fit(uintptr_t rlist, int rows);
+void    menu_list_fit(uintptr_t list, int armed);
+int     menu_list_fit_above_kbd(uintptr_t list, int row);
 void    menu_pane_labels(uintptr_t view, uintptr_t rmodel, const struct kit_row *r);
 void    menu_force_right_pane_sel(uintptr_t view, int sel_row);
 void    menu_force_right_pane(uintptr_t view);

--- a/package/deck/mods/menu/pane.c
+++ b/package/deck/mods/menu/pane.c
@@ -140,6 +140,98 @@ void menu_pane_fit(uintptr_t rlist, int rows)
     }
 }
 
+/* Give the DJ SETTING list room for MOD_ROWS_VISIBLE rows while the overlay is
+ * armed, and stock's own height back when it is not.
+ *
+ * Stock builds this list eight rows tall and leaves the panel beneath it blank,
+ * so an overlay of more rows rendered inside that viewport and scrolled. As with
+ * the right pane, the row height is measured from the stock-built list, once,
+ * and the armed height is that unit times the row count. What the list is sized
+ * for is published in menu_g_list_rows, which is what getNumRows reports: a list
+ * that could not be grown is left at its stock height and reports the stock
+ * count, so it scrolls rather than clips. */
+static int32_t g_list_rowh;      /* measured once from the stock-built list */
+static int32_t g_list_stock_h;
+
+void menu_list_fit(uintptr_t list, int armed)
+{
+    int32_t b[4], want;
+    int rows;
+
+    if (!list || mod_safe_read(list + COMP_BOUNDS_OFF, b, sizeof(b)) != 0) return;
+
+    if (!g_list_rowh) {
+        if (b[3] <= 0 || (b[3] % MOD_LIST_ROWS_STOCK) != 0) {
+            MDBG("djlist: %dx%d is not a clean %d rows -> not resizing\n",
+                 b[2], b[3], MOD_LIST_ROWS_STOCK);
+            g_list_rowh = -1;
+        } else {
+            g_list_rowh = b[3] / MOD_LIST_ROWS_STOCK;
+            g_list_stock_h = b[3];
+            MDBG("djlist: %dx%d at (%d,%d) -> row height %d\n",
+                 b[2], b[3], b[0], b[1], g_list_rowh);
+        }
+    }
+    if (g_list_rowh <= 0) return;
+
+    rows = armed ? MOD_ROWS_VISIBLE : MOD_LIST_ROWS_STOCK;
+    want = armed ? g_list_rowh * rows : g_list_stock_h;
+    if (b[1] + want > MOD_LIST_BOTTOM) {
+        MDBG("djlist: %d rows would end at %d, past %d -> staying stock-sized\n",
+             rows, b[1] + want, MOD_LIST_BOTTOM);
+        rows = MOD_LIST_ROWS_STOCK;
+        want = g_list_stock_h;
+    }
+    menu_g_list_rows = rows;
+    if (want == b[3]) return;
+    /* Growing back from the keyboard's cut goes past the target first. The cut
+     * list is scrolled and overflowing, so both of JUCE's scrollbars are up, and
+     * each keeps the other alive: the horizontal one takes the height that makes
+     * the content overflow vertically, the vertical one takes the width that
+     * makes it overflow horizontally, and the content stays scrolled by one bar.
+     * A viewport taller than the content has no use for either, and once they
+     * are gone the content is back at the top and fits the real size exactly. */
+    if (want > b[3])
+        ((void (*)(void *, int, int, int, int))FN_SET_BOUNDS)
+            ((void *)list, b[0], b[1], b[2], want + MOD_LIST_GROW_SLACK);
+    ((void (*)(void *, int, int, int, int))FN_SET_BOUNDS)
+        ((void *)list, b[0], b[1], b[2], want);
+    MDBG("djlist: resized to %dx%d for %d rows\n", b[2], want, rows);
+}
+
+/* Bring `row` out from under the software keyboard: the list is cut down to the
+ * rows above it and scrolled so `row` is the last one showing. Returns the
+ * on-screen row the editor belongs on, which is `row` itself when it was already
+ * clear of the keyboard. menu_list_fit grows the list back when the keyboard
+ * closes, and JUCE returns it to the top by itself: every row fits again, so
+ * there is nothing left to scroll.
+ *
+ * selectRow only scrolls when the selection changes, and `row` is the selection
+ * that opened the keyboard, so it is stepped off and back on. The bounce guard is
+ * up for both steps: the stock handler still runs (and rebuilds the right pane,
+ * which the caller hides again), the overlay's own does not. */
+int menu_list_fit_above_kbd(uintptr_t list, int row)
+{
+    int32_t b[4];
+    int above;
+
+    if (!list || g_list_rowh <= 0 ||
+        mod_safe_read(list + COMP_BOUNDS_OFF, b, sizeof(b)) != 0)
+        return row;
+    above = (MOD_KBD_TOP - b[1]) / g_list_rowh;
+    if (above < 2 || row < above) return row;
+
+    ((void (*)(void *, int, int, int, int))FN_SET_BOUNDS)
+        ((void *)list, b[0], b[1], b[2], above * g_list_rowh);
+    menu_g_bouncing = 1;
+    ((selectrow_t)FN_SELECT_ROW)((void *)list, row - 1, 1, 1);
+    ((selectrow_t)FN_SELECT_ROW)((void *)list, row, 0, 1);
+    menu_g_bouncing = 0;
+    MDBG("djlist: cut to %d rows for the keyboard, row %d shown at %d\n",
+         above, row, above - 1);
+    return above - 1;
+}
+
 void menu_pane_labels(uintptr_t view, uintptr_t rmodel, const struct kit_row *r)
 {
     uint8_t sa[JUCE_STRARRAY_BYTES] __attribute__((aligned(8))) = { 0 };

--- a/package/deck/mods/menu/pane.c
+++ b/package/deck/mods/menu/pane.c
@@ -147,11 +147,17 @@ void menu_pane_fit(uintptr_t rlist, int rows)
  * so an overlay of more rows rendered inside that viewport and scrolled. As with
  * the right pane, the row height is measured from the stock-built list, once,
  * and the armed height is that unit times the row count. What the list is sized
- * for is published in menu_g_list_rows, which is what getNumRows reports: a list
- * that could not be grown is left at its stock height and reports the stock
- * count, so it scrolls rather than clips. */
+ * for is published in menu_g_list_rows, which is what getNumRows reports, and
+ * handed to the kit as its ceiling: a list that could not be grown stays at its
+ * stock height, and the rows past what it shows are dropped with a warning
+ * rather than left undrawn and unselectable. */
 static int32_t g_list_rowh;      /* measured once from the stock-built list */
 static int32_t g_list_stock_h;
+
+int menu_list_row_h(void)
+{
+    return g_list_rowh > 0 ? g_list_rowh : MOD_ROW_H;
+}
 
 void menu_list_fit(uintptr_t list, int armed)
 {
@@ -161,7 +167,9 @@ void menu_list_fit(uintptr_t list, int armed)
     if (!list || mod_safe_read(list + COMP_BOUNDS_OFF, b, sizeof(b)) != 0) return;
 
     if (!g_list_rowh) {
-        if (b[3] <= 0 || (b[3] % MOD_LIST_ROWS_STOCK) != 0) {
+        if (b[3] <= 0)
+            return;                 /* not laid out yet: measure next time */
+        if ((b[3] % MOD_LIST_ROWS_STOCK) != 0) {
             MDBG("djlist: %dx%d is not a clean %d rows -> not resizing\n",
                  b[2], b[3], MOD_LIST_ROWS_STOCK);
             g_list_rowh = -1;
@@ -176,13 +184,15 @@ void menu_list_fit(uintptr_t list, int armed)
 
     rows = armed ? MOD_ROWS_VISIBLE : MOD_LIST_ROWS_STOCK;
     want = armed ? g_list_rowh * rows : g_list_stock_h;
-    if (b[1] + want > MOD_LIST_BOTTOM) {
+    /* The slack counts: the grow below passes through want + slack. */
+    if (b[1] + want + MOD_LIST_GROW_SLACK > MOD_LIST_BOTTOM) {
         MDBG("djlist: %d rows would end at %d, past %d -> staying stock-sized\n",
              rows, b[1] + want, MOD_LIST_BOTTOM);
         rows = MOD_LIST_ROWS_STOCK;
         want = g_list_stock_h;
     }
     menu_g_list_rows = rows;
+    kit_menu_set_shown(rows - MOD_ROW_FIRST);
     if (want == b[3]) return;
     /* Growing back from the keyboard's cut goes past the target first. The cut
      * list is scrolled and overflowing, so both of JUCE's scrollbars are up, and

--- a/package/deck/mods/menu/state.c
+++ b/package/deck/mods/menu/state.c
@@ -14,6 +14,7 @@ uintptr_t menu_g_orig_numrows, menu_g_orig_paintcell, menu_g_orig_mousedown, men
                  menu_g_orig_rnumrows;
 int       menu_g_render_ok;   /* JUCE render primitives verified at install */
 int       menu_g_mod_mode;    /* 1 while the mod overlay is drawing over DJ SETTING */
+int       menu_g_list_rows = MOD_LIST_ROWS_STOCK;
 uintptr_t menu_g_model;       /* DJSettingTableModel, captured in paintCell */
 uintptr_t menu_g_view;        /* UTILITY view, captured from the hooks that get it */
 int       menu_g_bouncing;    /* re-entry guard for the title-row bounce */

--- a/package/deck/mods/menu/view.c
+++ b/package/deck/mods/menu/view.c
@@ -27,10 +27,14 @@ void menu_refresh_djlist(void *view)
             mod_safe_read(list, &vt, sizeof(vt));
             MDBG("djlist=%#lx vt=%#lx model@+%#lx\n",
                  (unsigned long)list, (unsigned long)vt, (unsigned long)off);
+            /* Size first: updateContent lays the rows out against the bounds the
+             * list has at that moment. */
+            menu_list_fit(list, menu_g_mod_mode);
             ((void (*)(void *))FN_UPDATECONTENT)((void *)list);
-            /* updateContent only re-lays-out when the row COUNT changes, and we keep it
-             * equal to stock, so ask for the repaint outright: the row components call
-             * paintCell again and pick up the new mode. */
+            /* updateContent only re-lays-out when the row COUNT changes, which a
+             * dismiss that stays on DJ SETTING does not do, so ask for the repaint
+             * outright: the row components call paintCell again and pick up the
+             * new mode. */
             ((void (*)(void *))FN_REPAINT)((void *)list);
             return;
         }

--- a/package/deck/mods/stem/audio.c
+++ b/package/deck/mods/stem/audio.c
@@ -305,15 +305,17 @@ struct probe g_op_probe = { "operate", EP122_TSMGR, 0, 0 };
  *
  * What remains is the worker's usleep (<=100 ms) and the length probe (~0.5-2 s
  * for an 8-minute track), so a fast track change still cannot be instant. */
-/* ONE SIGNAL: the sourceId moving, resolved to a path and acted on HERE, on the
- * message thread -- the sequence below moves Sliders.
+/* ONE THING: the sourceId, resolved to a path and acted on HERE, on the message
+ * thread -- the sequence below moves Sliders. Two ways of learning it.
  *
- * The id is the only thing that names the track, and it comes off the page pool,
- * so for a while it looked like a signal a paused deck could not produce. It can:
- * a deck parked at the cue point still pre-buffers, and those reads carry the
- * track's id with a countdown in the top half. Masking that half rather than
- * rejecting it is what makes AUTO CUE work -- see the sourceId comment in the
- * page-read hook.
+ * The id is the only thing that names the track. It comes off the page pool's
+ * reads, and a deck parked at the cue point still pre-buffers, so those reads
+ * carry the track's id with a countdown in the top half -- masking that half
+ * rather than rejecting it is what makes AUTO CUE work (see the sourceId
+ * comment in the page-read hook). A deck loaded and left at 0:00 with AUTO CUE
+ * off reads nothing at all, and for that the id is taken from the deck's own
+ * load result, which names the same track whether or not it will ever be
+ * played. Both feed one act, deduplicated on the path.
  *
  * Deduplicated on the PATH, because the same track arriving twice is one track. */
 /* Called from the play-screen paint hook, i.e. the juce message thread, where
@@ -602,10 +604,49 @@ static void *const k_probe_wrapper[N_PROBE] = {
  * the audio path is not something to start patching once samples are flowing.
  * The wrapper chains straight to the stock call, so with STEMS off the cost is
  * a predictable branch per block; the mix itself gets gated per call. */
+/* ---- the load event ------------------------------------------------------ */
+
+/* onLoadResult's closure: the SourceId at +0x18/+0x20 (sub_107ee20 stores the
+ * two words of the id there) and the Result at +0x30. */
+#define LOAD_SID_OFF     0x18
+#define LOAD_RESULT_OFF  0x30
+#define VT_SLOT_RUN      0x10
+
+struct stem_load_state g_load;
+static uintptr_t g_orig_loadresult;
+
+static void *stem_load_result(void *task)
+{
+    uint64_t lo = 0, hi = 0;
+    int32_t result = 0;
+
+    if (mod_safe_read((uintptr_t)task + LOAD_SID_OFF, &lo, sizeof(lo)) == 0 &&
+        mod_safe_read((uintptr_t)task + LOAD_SID_OFF + 8, &hi, sizeof(hi)) == 0 &&
+        mod_safe_read((uintptr_t)task + LOAD_RESULT_OFF, &result, sizeof(result)) == 0) {
+        uint32_t gen = g_load.gen;
+
+        __atomic_store_n(&g_load.gen, gen + 1, __ATOMIC_RELAXED);
+        __atomic_thread_fence(__ATOMIC_RELEASE);
+        g_load.sid_lo = lo;
+        g_load.sid_hi = hi & 0xffffffffull;   /* masked as the reads mask it */
+        g_load.result = result;
+        __atomic_thread_fence(__ATOMIC_RELEASE);
+        __atomic_store_n(&g_load.gen, gen + 2, __ATOMIC_RELAXED);
+    }
+    return ((void *(*)(void *))g_orig_loadresult)(task);
+}
+
 static int stem_audio_install(void)
 {
     char name[64];
     int i;
+
+    /* Not fatal: without it a track loaded and left paused waits for its first
+     * read, which is how every build before this behaved. */
+    if (mod_patch_vslot("stemLoadResult", EP122_PCM_LOADRESULT_TASK, VT_SLOT_RUN,
+                        (void *)stem_load_result, &g_orig_loadresult) != 0)
+        g_orig_loadresult = 0;
+    MDBG("stem_audio: load result %s\n", g_orig_loadresult ? "armed" : "SKIPPED");
 
     for (i = 0; i < N_PROBE; i++) {
         struct probe *p = &g_probe[i];

--- a/package/deck/mods/stem/audio.c
+++ b/package/deck/mods/stem/audio.c
@@ -56,6 +56,7 @@
 #include "wave/wave.h"
 
 #include <fcntl.h>
+#include <pthread.h>
 #include <stdlib.h>
 #include <unistd.h>
 
@@ -606,34 +607,55 @@ static void *const k_probe_wrapper[N_PROBE] = {
  * a predictable branch per block; the mix itself gets gated per call. */
 /* ---- the load event ------------------------------------------------------ */
 
-/* onLoadResult's closure: the SourceId at +0x18/+0x20 (sub_107ee20 stores the
- * two words of the id there) and the Result at +0x30. */
-#define LOAD_SID_OFF     0x18
-#define LOAD_RESULT_OFF  0x30
-#define VT_SLOT_RUN      0x10
+/* onLoadResult's closure: the PcmBufferFunctionHandler at +0x28, the SourceId
+ * at +0x18/+0x20 (sub_107ee20 stores the two words of the id there) and the
+ * Result at +0x30. The stock run (3.19 sub_107e3d8) takes the result only while
+ * the handler is loading (+0x110 == 1) and the id is its current load, then
+ * sets +0x110 to 2 for a good load and 3 for a failed one. */
+#define LOAD_HANDLER_OFF        0x28
+#define LOAD_SID_OFF            0x18
+#define HANDLER_LOAD_STATE_OFF  0x110
+#define LOAD_STATE_LOADED       2
+#define VT_SLOT_RUN             0x10
 
 struct stem_load_state g_load;
 static uintptr_t g_orig_loadresult;
+/* One writer at a time on the seqlock; the message-thread reader stays
+ * lock-free. Two task threads with the same base would leave gen even over a
+ * torn id. */
+static pthread_mutex_t g_load_mu = PTHREAD_MUTEX_INITIALIZER;
 
-static void *stem_load_result(void *task)
+static void stem_load_result(void *task)
 {
     uint64_t lo = 0, hi = 0;
-    int32_t result = 0;
+    uintptr_t handler = 0;
+    int32_t state = 0;
+    int have = mod_safe_read((uintptr_t)task + LOAD_HANDLER_OFF, &handler, sizeof(handler)) == 0 &&
+               mod_safe_read((uintptr_t)task + LOAD_SID_OFF, &lo, sizeof(lo)) == 0 &&
+               mod_safe_read((uintptr_t)task + LOAD_SID_OFF + 8, &hi, sizeof(hi)) == 0;
 
-    if (mod_safe_read((uintptr_t)task + LOAD_SID_OFF, &lo, sizeof(lo)) == 0 &&
-        mod_safe_read((uintptr_t)task + LOAD_SID_OFF + 8, &hi, sizeof(hi)) == 0 &&
-        mod_safe_read((uintptr_t)task + LOAD_RESULT_OFF, &result, sizeof(result)) == 0) {
+    ((void (*)(void *))g_orig_loadresult)(task);
+
+    /* Judged AFTER the stock run, by the handler's own state: a failed or a
+     * superseded load leaves it anything but LOADED, and acting on that tore
+     * down the stems of the track that is actually playing. */
+    if (!have || !handler ||
+        mod_safe_read(handler + HANDLER_LOAD_STATE_OFF, &state, sizeof(state)) != 0 ||
+        state != LOAD_STATE_LOADED)
+        return;
+
+    pthread_mutex_lock(&g_load_mu);
+    {
         uint32_t gen = g_load.gen;
 
         __atomic_store_n(&g_load.gen, gen + 1, __ATOMIC_RELAXED);
         __atomic_thread_fence(__ATOMIC_RELEASE);
         g_load.sid_lo = lo;
         g_load.sid_hi = hi & 0xffffffffull;   /* masked as the reads mask it */
-        g_load.result = result;
         __atomic_thread_fence(__ATOMIC_RELEASE);
         __atomic_store_n(&g_load.gen, gen + 2, __ATOMIC_RELAXED);
     }
-    return ((void *(*)(void *))g_orig_loadresult)(task);
+    pthread_mutex_unlock(&g_load_mu);
 }
 
 static int stem_audio_install(void)

--- a/package/deck/mods/stem/audio_internal.h
+++ b/package/deck/mods/stem/audio_internal.h
@@ -120,18 +120,29 @@ struct stem_src_state {
     /* Bumped by the audio thread whenever the sourceId changes, i.e. whenever a
      * different track starts being read.
      *
-     * This is the ONLY honest track-change signal available. setSource looked
-     * like the obvious one and is not: it fires twice at player construction
-     * and never again, because there is a single PageBuffer for the whole pool
-     * and tracks are switched by the sourceId inside each Position rather than
-     * by installing a new source. decode.c's `open` hook is not it either -- the
-     * preview player opens files too, so browsing would launch separations for
-     * tracks nobody loaded.
+     * One of the two honest track-change signals, with g_load below the other.
+     * setSource looked like the obvious one and is not: it fires twice at player
+     * construction and never again, because there is a single PageBuffer for the
+     * whole pool and tracks are switched by the sourceId inside each Position
+     * rather than by installing a new source. decode.c's `open` hook is not it
+     * either -- the preview player opens files too, so browsing would launch
+     * separations for tracks nobody loaded.
      *
      * A counter rather than a flag so the reader cannot miss two changes in one
      * window, and relaxed because a change is acted on from the message thread
      * where being one window late costs nothing. */
     uint32_t   track_gen;
+};
+
+/* The deck's own "the track is in the pool": PcmBufferFunctionHandler::
+ * onLoadResult's task, which carries the load's SourceId and Result. The reads
+ * above only move once the pool is read, and a deck loaded and left at 0:00
+ * with AUTO CUE off reads nothing -- this is what fires for that load. Written
+ * by the task's thread under a seqlock, read from the message thread. */
+struct stem_load_state {
+    volatile uint32_t gen;
+    uint64_t   sid_lo, sid_hi;
+    int32_t    result;
 };
 
 struct stem_xp_gate { uint64_t hit, miss, saw; };
@@ -144,6 +155,7 @@ struct stem_xp_lag {
 /* All defined in audio.c, which owns the hooks that write them. */
 extern struct stem_op_stats g_op;
 extern struct stem_src_state g_src;
+extern struct stem_load_state g_load;
 extern struct stem_xp_gate g_xp_gate;
 extern struct stem_xp_lag g_xp_lag;
 extern int g_engine_rate;

--- a/package/deck/mods/stem/audio_internal.h
+++ b/package/deck/mods/stem/audio_internal.h
@@ -141,8 +141,7 @@ struct stem_src_state {
  * by the task's thread under a seqlock, read from the message thread. */
 struct stem_load_state {
     volatile uint32_t gen;
-    uint64_t   sid_lo, sid_hi;
-    int32_t    result;
+    uint64_t   sid_lo, sid_hi;          /* the id of a load that succeeded */
 };
 
 struct stem_xp_gate { uint64_t hit, miss, saw; };

--- a/package/deck/mods/stem/audio_probe.c
+++ b/package/deck/mods/stem/audio_probe.c
@@ -55,9 +55,30 @@ static void stem_track_act(const char *path, const char *why)
 
 static void stem_track_watch(void)
 {
-    static uint32_t seen_track;
+    static uint32_t seen_track, seen_load;
     uint32_t gen = __atomic_load_n(&g_src.track_gen, __ATOMIC_RELAXED);
-    char sid[48];
+    uint32_t lgen = __atomic_load_n(&g_load.gen, __ATOMIC_RELAXED);
+    char sid[64];
+
+    /* The load event first: it is the earlier of the two on a deck that loads
+     * and does not play, and on one that does the reads follow with the same id
+     * and stem_track_act sees the same path. */
+    if (lgen != seen_load && !(lgen & 1u)) {
+        uint64_t lo, hi;
+        int32_t result;
+
+        __atomic_thread_fence(__ATOMIC_ACQUIRE);
+        lo = g_load.sid_lo;
+        hi = g_load.sid_hi;
+        result = g_load.result;
+        __atomic_thread_fence(__ATOMIC_ACQUIRE);
+        if (__atomic_load_n(&g_load.gen, __ATOMIC_RELAXED) == lgen) {
+            seen_load = lgen;
+            snprintf(sid, sizeof(sid), "loaded sid %llx:%llx result %d",
+                     (unsigned long long)hi, (unsigned long long)lo, result);
+            stem_track_act(stem_decode_path_for_sid(lo, hi), sid);
+        }
+    }
 
     if (gen == seen_track)
         return;

--- a/package/deck/mods/stem/audio_probe.c
+++ b/package/deck/mods/stem/audio_probe.c
@@ -27,7 +27,9 @@ static void stem_track_act(const char *path, const char *why)
 {
     static char acted_on[STEM_CACHE_PATH_MAX];
 
-    if (path && acted_on[0] && strcmp(path, acted_on) == 0)
+    /* Once per track, and once per "no track": a load with no path tears the
+     * previous set down, and the read that follows it must not do so again. */
+    if (path ? (acted_on[0] && strcmp(path, acted_on) == 0) : !acted_on[0])
         return;
     snprintf(acted_on, sizeof(acted_on), "%s", path ? path : "");
 
@@ -65,17 +67,15 @@ static void stem_track_watch(void)
      * and stem_track_act sees the same path. */
     if (lgen != seen_load && !(lgen & 1u)) {
         uint64_t lo, hi;
-        int32_t result;
 
         __atomic_thread_fence(__ATOMIC_ACQUIRE);
         lo = g_load.sid_lo;
         hi = g_load.sid_hi;
-        result = g_load.result;
         __atomic_thread_fence(__ATOMIC_ACQUIRE);
         if (__atomic_load_n(&g_load.gen, __ATOMIC_RELAXED) == lgen) {
             seen_load = lgen;
-            snprintf(sid, sizeof(sid), "loaded sid %llx:%llx result %d",
-                     (unsigned long long)hi, (unsigned long long)lo, result);
+            snprintf(sid, sizeof(sid), "loaded sid %llx:%llx",
+                     (unsigned long long)hi, (unsigned long long)lo);
             stem_track_act(stem_decode_path_for_sid(lo, hi), sid);
         }
     }


### PR DESCRIPTION
Two independent fixes, no tracker issue:

- **Paused load.** With AUTO CUE off and the deck paused when a track is loaded, the new track loads paused and nothing reads audio, so the stem job only started at PLAY (measured on the emulator: 15 s between the deck opening the file and the job). The deck's own load notification (PcmBufferFunctionHandler::onLoadResult, resolved by RTTI on both SoCs) now triggers the request at the load. AUTO CUE on, or a deck that is playing, already read audio at the load and were never affected.
- **MOD SETTINGS address row.** The kit capped the live list at 7 rows while every mod on with the server location at MANUAL is 8, so STEM SERVER ADDRESS was always the row dropped and a manual address could not be typed. The overlay now grows the DJ SETTING list to 10 rows while armed and hands stock its height back on dismiss; the keyboard scrolls a row it would cover into view and the list is restored, scrollbar-free, on close.

**After review** (two more commits): the load hook chains the stock run first and publishes only when the handler reads LOADED, so a failed or superseded load no longer tears down the playing track's stems; the publish is serialised between task threads; a load with no path tears down once. The kit's row ceiling follows what the list could be sized for, so on a skin where the list cannot grow the eighth row is dropped with the usual warning instead of drawn nowhere; a list not laid out yet is measured on a later pass; the editor is placed with the measured row height.

Tested including a side-by-side with main for the paused load. Adds PCM_LOADRESULT entries to the symbol spec; the header is generated and will conflict textually with the stems PR, regenerate it from the spec on whichever lands second.
