### PR TITLE
fix(stem): update LAN notice and documentation link in job settings

### DIFF
--- a/package/deck/mods/stem/job_settings.c
+++ b/package/deck/mods/stem/job_settings.c
@@ -11,10 +11,10 @@ static const char *const k_addr_error[] = {
 };
 
 static const char *const k_stems_notice[] = {
-    "A stemd app must be reachable from the LAN",
+    "The stemd app must be reachable from the LAN",
     "",
     "setup instructions:",
-    "cdj3k-mods.com/manual/stems",
+    "cdj3k-mods.com/docs/stems",
 };
 #include "core/mod_settings.h"
 #include "wave/wave.h"


### PR DESCRIPTION
Corrects the LAN notice text and the documentation link shown from the STEMS rows in MOD SETTINGS.