### PR TITLE
fix(core): regenerate ep122_syms.h after #11 and #12

### DIFF
--- a/package/deck/mods/core/ep122_syms.h
+++ b/package/deck/mods/core/ep122_syms.h
@@ -342,7 +342,7 @@ static const struct ep122_vt_spec {
     { EP122_GRIDBTN_SHIFT, "N3gui18grid_adjust_button15ShiftGridButtonE", NULL },   /* 0x20f69d0 */
     { EP122_GRIDBTN_RESET, "N3gui18grid_adjust_button11ResetButtonE", NULL },   /* 0x20f7a30 */
 };
-#define EP122_N_VT 84
+#define EP122_N_VT 85
 
 /* ---- virtuals: whatever the slot holds IS the implementation ---- */
 static const struct ep122_slot_spec {


### PR DESCRIPTION
After #11 and #12 both added vtable entries, main's generated header lists 85 vtable specs but says `EP122_N_VT 84`, so the resolver skips the last one, `GRIDBTN_RESET`, and the grid panel's reset button goes unresolved at runtime. Regenerated from the spec with both reference binaries; `gen-syms.py --check` is clean again. No spec change.