### PR TITLE
fix(stem): progress bar percentage

### DIFF
--- a/package/deck/mods/stem/ui/row.c
+++ b/package/deck/mods/stem/ui/row.c
@@ -273,9 +273,7 @@ static int stems_prog_pos(int stage, int pct, int via_server)
     switch (stage) {
     case STEM_STAGE_UPLOADING:
         return pct * PROG_BOUND_UPLOAD / 100;
-    /* The server's tail, sharing the third segment with the download. A span each,
-     * so the pair stays monotone whichever question stemd's fraction answers -- see
-     * ui.h, which is the only place that reasoning belongs. */
+    /* The server's tail, sharing the third segment with the download. See ui.h. */
     case STEM_STAGE_RECONSTRUCTING:
         return PROG_BOUND_SEPARATE +
                pct * (PROG_BOUND_RECON - PROG_BOUND_SEPARATE) / 100;
@@ -293,8 +291,9 @@ static int stems_prog_pos(int stage, int pct, int via_server)
     case STEM_STAGE_DONE:
         return 100;
     default:
-        /* QUEUED, ANALYZING, SEPARATING: stemd's own fraction, which is where nearly
-         * all of a job's time goes and so gets the widest segment. */
+        /* QUEUED, ANALYZING, SEPARATING share the second segment. Only separating
+         * reports a count; the other two send 0. Most of a job's time is spent here,
+         * hence the widest segment. */
         return PROG_BOUND_UPLOAD +
                pct * (PROG_BOUND_SEPARATE - PROG_BOUND_UPLOAD) / 100;
     }

--- a/package/deck/mods/stem/ui/ui.h
+++ b/package/deck/mods/stem/ui/ui.h
@@ -175,7 +175,7 @@ extern "C" {
  * FOUR SEGMENTS, and each one is reached:
  *
  *   |  upload  |========  separating  ========|  prepare + fetch  |  load  |
- *   0         20                             80                 95      100
+ *   0         20                             80                 90      100
  *
  * The third segment used to hold the download alone, five points wide, and the sidecar
  * reported that leg as `part index / part count` -- 0 then 50 for a pair, never 100. So
@@ -189,21 +189,13 @@ extern "C" {
  * DJ sees the caption change inside it rather than the bar hand over. */
 #define PROG_BOUND_UPLOAD    20  /* the deck's PCM upload ends here       */
 #define PROG_BOUND_SEPARATE  80  /* the model's own work ends here        */
-/* The two interior splits of the third segment, drawn with no delimiter between them.
- *
- * RECONSTRUCTING and WRITING GET A SPAN EACH RATHER THAN SHARING ONE, and that is the
- * only thing here that is defensive rather than measured. stemd reports a single
- * `fraction` and we do not get to see which question it is answering: read as the
- * whole job's it is already near 1 by the time these run, read as the stage's it
- * restarts at 0 for each. Sharing one span is monotone under the first reading and
- * steps BACKWARDS under the second. A span each is monotone under both -- the worst
- * it can do is put a stage at the top of its own four points and step to the next.
- *
- * They still share a caption, because the boundary between them is stemd's business
- * and not a thing the DJ can act on. See k_stage_name in row.c. */
-#define PROG_BOUND_RECON     84  /* reconstruction ends                   */
-#define PROG_BOUND_WRITE     88  /* the server has the files ready        */
-#define PROG_BOUND_FETCH     95  /* the two stems have landed by here     */
+/* RECONSTRUCTING and WRITING share the third segment with DOWNLOADING; no delimiter
+ * between them. stemd sends no progress count for these two stages: 1% each, the
+ * bar holds at the start of each until the next stage begins. Both use the caption
+ * PREPARING (k_stage_name in row.c). */
+#define PROG_BOUND_RECON     81  /* reconstruction ends                   */
+#define PROG_BOUND_WRITE     82  /* the server has the files ready        */
+#define PROG_BOUND_FETCH     90  /* the two stems have landed by here     */
 #define PROG_BOUND_LIST     { PROG_BOUND_UPLOAD, PROG_BOUND_SEPARATE, PROG_BOUND_FETCH }
 #define N_PROG_BOUND        3    /* one delimiter per SEGMENT boundary    */
 #define PROG_MARK_W         2

--- a/package/deck/shared/stem_proto.h
+++ b/package/deck/shared/stem_proto.h
@@ -183,11 +183,10 @@ enum stem_stage {
 
 struct stem_progress {
     uint32_t stage;              /* enum stem_stage */
-    /* 0..100 WITHIN THE SENDER'S OWN LEG: the separation's own fraction while the
-     * server has the job, the download's own count while this end is pulling the two
-     * stems. Weighting those onto one bar is the DECK's, because the division of the
-     * bar is the deck's -- a leg that reports a position on that bar instead makes it
-     * step backwards at the handover. */
+    /* 0..100 of the current stage only: the server's completed/total for that stage
+     * (0 when it reports none), or bytes downloaded over Content-Length while
+     * fetching. Never the whole job's fraction and never a bar position: the deck
+     * maps stages onto the bar. */
     uint32_t percent;
     uint32_t queue_position;     /* jobs ahead of us; meaningful when QUEUED */
     uint32_t reserved;

--- a/package/deck/stemd_client/http.c
+++ b/package/deck/stemd_client/http.c
@@ -376,6 +376,9 @@ int http_perform(const struct stem_server *srv, const struct http_request *req)
 
     /* Chunked wins if both are present, per RFC 7230. A 204 or a HEAD-like
      * empty response has neither and no body to read. */
+    if (req->begin)
+        req->begin(!chunked && have_len ? body_len : HTTP_BODY_LEN_UNKNOWN,
+                   req->push_user);
     if (chunked) {
         if (drain_chunked(&c, req->push, req->push_user) != 0)
             status = -1;

--- a/package/deck/stemd_client/session.c
+++ b/package/deck/stemd_client/session.c
@@ -237,10 +237,24 @@ static size_t upload_pull(void *buf, size_t cap, void *user)
 
 /* ---- fetching a stem ------------------------------------------------------ */
 
+/* One stem being downloaded. Its progress runs from `base` to `base + span` percent
+ * of the download stage, computed from bytes written over Content-Length. Without
+ * a Content-Length it stays at `base`. */
 struct stem_out {
-    int      fd;
-    uint64_t written;
+    int      fd;            /* the .part file */
+    uint64_t written;       /* body bytes on disk */
+    int      ctl;           /* the shim socket PROGRESS frames go to */
+    uint64_t expected;      /* Content-Length, or 0 when unknown */
+    int      base, span;    /* this stem's range of the download stage, percent */
+    int      sent;          /* last percent sent; unchanged means no frame */
 };
+
+static void stem_begin(uint64_t len, void *user)
+{
+    struct stem_out *o = user;
+
+    o->expected = (len == HTTP_BODY_LEN_UNKNOWN) ? 0 : len;
+}
 
 static int stem_sink(const void *buf, size_t len, void *user)
 {
@@ -260,6 +274,16 @@ static int stem_sink(const void *buf, size_t len, void *user)
         return -1;
     }
     o->written += len;
+
+    /* drain_body caps at the announced length, so this never passes base + span. */
+    if (o->expected) {
+        int pct = o->base + (int)((o->written * (uint64_t)o->span) / o->expected);
+
+        if (pct != o->sent) {
+            o->sent = pct;
+            send_progress(o->ctl, STEM_STAGE_FETCHING, pct);
+        }
+    }
     return 0;
 }
 
@@ -311,10 +335,11 @@ static const char *out_format_name(uint32_t f)
     }
 }
 
-/* GET one stem into tmpfs and tell the shim where it is. */
+/* GET one stem into tmpfs and tell the shim where it is. `base`/`span`: see
+ * struct stem_out. */
 static int fetch_stem(int fd, const struct stem_server *srv, const char *job_id,
                       const char *name, uint32_t rate, uint32_t frames,
-                      uint32_t format, float gain)
+                      uint32_t format, float gain, int base, int span)
 {
     char path[192], part[200], url[192];
     unsigned char hdr[44];
@@ -350,8 +375,12 @@ static int fetch_stem(int fd, const struct stem_server *srv, const char *job_id,
     snprintf(part, sizeof(part), "%s.part", path);
     snprintf(url, sizeof(url), "/v1/jobs/%s/stems/%s", job_id, name);
 
+    memset(&out, 0, sizeof(out));
     out.fd = open(part, O_WRONLY | O_CREAT | O_TRUNC, 0600);
-    out.written = 0;
+    out.ctl = fd;
+    out.base = base;
+    out.span = span;
+    out.sent = -1;
     if (out.fd < 0) {
         SERR("cannot create %s: %s\n",
                 part, strerror(errno));
@@ -375,6 +404,7 @@ static int fetch_stem(int fd, const struct stem_server *srv, const char *job_id,
     memset(&req, 0, sizeof(req));
     req.method = "GET";
     req.path = url;
+    req.begin = stem_begin;
     req.push = stem_sink;
     req.push_user = &out;
     status = http_perform(srv, &req);
@@ -505,11 +535,25 @@ static int await_job(int fd, const struct stem_server *srv, const char *job_id,
             return -1;
         }
 
-        memset(&prog, 0, sizeof(prog));
-        prog.stage = (uint32_t)stage;
-        prog.percent = (uint32_t)(json_num(final_doc->data, "fraction", 0.0)
-                                  * 100.0);
-        prog.queue_position = (uint32_t)json_num(final_doc->data, "completed", 0);
+        /* Progress of the current stage only: `completed` / `total`. `fraction` is
+         * the whole job and is not used. Stages without a count (analysing,
+         * reconstructing, writing) send 0. While QUEUED, `completed` is the queue
+         * position. */
+        {
+            double completed = json_num(final_doc->data, "completed", 0);
+            double total = json_num(final_doc->data, "total", 0);
+            int pct = 0;
+
+            if (stage != STEM_STAGE_QUEUED && total > 0 && completed > 0)
+                pct = (int)(completed * 100.0 / total);
+            if (pct > 100)
+                pct = 100;
+
+            memset(&prog, 0, sizeof(prog));
+            prog.stage = (uint32_t)stage;
+            prog.percent = (uint32_t)pct;
+            prog.queue_position = (uint32_t)completed;
+        }
         send_frame(fd, STEM_MSG_PROGRESS, &prog, sizeof(prog));
 
         if (stage == STEM_STAGE_DONE)
@@ -798,24 +842,24 @@ void session_run(int fd)
                  * here is a bar that steps BACKWARDS when the server hands over,
                  * because it is answering a different question than the stage before it.
                  *
-                 * BOTH ENDS OF EACH STEM, which is what was missing: reporting only
-                 * `i / n` before each pull sends 0 and 50 for a pair and stops. The leg
-                 * ends at half its own length for ever, so the deck's third segment was
-                 * left part-filled and the next thing drawn was the local decode at the
-                 * start of the fourth -- a segment the bar visibly never crossed. */
+                 * Each stem gets an equal range of the download stage and reports
+                 * bytes as they arrive (struct stem_out). The range's start is sent
+                 * before each download; 100 only once every stem is on disk, since a
+                 * failed download has already reported FAILED. */
                 for (i = 0; i < n; i++) {
-                    send_progress(fd, STEM_STAGE_FETCHING, (i * 100) / n);
+                    const int base = (i * 100) / n;
+                    const int span = ((i + 1) * 100) / n - base;
+
+                    send_progress(fd, STEM_STAGE_FETCHING, base);
                     if (fetch_stem(fd, &srv, job_id, k_part[i], rate, job_frames,
                                    job_format,
-                                   stem_gain(doc.data, k_part[i])) != 0) {
+                                   stem_gain(doc.data, k_part[i]),
+                                   base, span) != 0) {
                         report_failed(fd, 0);
                         break;
                     }
                     got = i + 1;
                 }
-                /* Only a COMPLETE fetch closes the leg. A pull that died half way has
-                 * already reported failed, and following it with a full bar would be
-                 * the last thing the DJ saw before the row went grey. */
                 if (got == n)
                     send_progress(fd, STEM_STAGE_FETCHING, 100);
             }

--- a/package/deck/stemd_client/stemd_client.h
+++ b/package/deck/stemd_client/stemd_client.h
@@ -115,6 +115,11 @@ typedef size_t (*http_body_pull_fn)(void *buf, size_t cap, void *user);
 /* A streamed response body: `push` receives each chunk as it arrives. */
 typedef int (*http_body_push_fn)(const void *buf, size_t len, void *user);
 
+/* The response body's size, called once before the first push. HTTP_BODY_LEN_UNKNOWN
+ * when the headers do not say (chunked, or read to EOF). */
+#define HTTP_BODY_LEN_UNKNOWN ((uint64_t)-1)
+typedef void (*http_body_begin_fn)(uint64_t len, void *user);
+
 struct http_request {
     const char *method;
     const char *path;             /* including any query string */
@@ -122,8 +127,9 @@ struct http_request {
     uint64_t    content_length;   /* exact, so no chunked encoding is needed */
     http_body_pull_fn pull;
     void       *pull_user;
+    http_body_begin_fn begin;     /* NULL when the size is of no interest */
     http_body_push_fn push;       /* NULL to discard the response body */
-    void       *push_user;
+    void       *push_user;        /* handed to both begin and push */
 };
 
 /* Perform one request. Returns the HTTP status, or -1 on a transport failure. */


### PR DESCRIPTION
Fixes the aberent stem progress bar that was jumping on the 3rd segment (80 -> 84 -> 92)

<img width="710" height="590" alt="image" src="https://github.com/user-attachments/assets/71bfd628-b4c7-4eb0-84da-d1c56f06e0d7" />
