### PR TITLE
docs: README screenshots, gate cue needs a paused deck, the stems progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ A set of modifications for the CDJ-3000, installed as a firmware update. They
 run alongside the deck's own application rather than replacing it, and come off
 from the front panel.
 
+<p align="center">
+  <img src="https://cdj3k-mods.com/img/stems-row-unity.png" width="49%" alt="The STEMS row: drums, harmonics and vocals on three faders over the play screen">
+  <img src="https://cdj3k-mods.com/img/theme-comb.png" width="49%" alt="The play screen in six of the themes, one vertical strip each">
+</p>
+
 Features:
 
 - **Cues** — gate cues (hold to play, release to return), smart cues (last hot cue is cue), and

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ from the front panel.
 
 Features:
 
-- **Cues** — gate cues (hold to play, release to return), smart cues (last hot cue is cue), and
-  preview hot cue to set a hot cue with the preview.
+- **Cues** — gate cues (press a pad while paused: hold to play, release to
+  return), smart cues (last hot cue is cue), and preview hot cue to set a hot
+  cue with the preview.
 - **Stems** — drums, harmonics and vocals on three toggles and three faders.
   Separation runs on a computer on your network via
   [stemd](https://github.com/nsaintot/stemd), not on the deck. Groove circuit

--- a/docs/stems.md
+++ b/docs/stems.md
@@ -28,9 +28,10 @@ In [MOD SETTINGS](mod-settings.md):
 ## What happens when you load a track
 
 When you load a track, the deck uploads it to the server, which processes it and
-returns the separated parts. For reference, on an M1 Pro with a Balanced setup,
-an eight-minute track typically took **about 25 seconds** to process.
-track plays normally throughout, and the faders become live when the parts
+returns the separated parts. This starts at the load, whether the track is
+playing or sits paused on its cue. For reference, on an M1 Pro with a Balanced
+setup, an eight-minute track typically took **about 25 seconds** to process.
+The track plays normally throughout, and the faders become live when the parts
 arrive.
 
 - **The second deck is free.** Two decks loading the same track cost one
@@ -101,6 +102,13 @@ The row sits under the waveform: three controls, one per part (**DRUMS**,
 of the row.
 
 ![The STEMS row open with all three at full.](img/stems-row-unity.png)
+
+While the parts are on their way, the row shows a progress bar in place of the
+faders, captioned with the step in hand: **UPLOADING**, **SEPARATING**,
+**PREPARING**, **DOWNLOADING**, then **LOADING**. Separating is the long one.
+PREPARING holds still while the server writes the parts, since it reports no
+count for that step. A track whose stems are already on the stick skips the
+server and only shows LOADING.
 
 | | |
 | --- | --- |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -62,6 +62,11 @@ Check in this order:
 **GATE CUE is off.** Turn it on in [MOD SETTINGS](mod-settings.md), or with the
 shortcut on the play screen.
 
+**The deck was playing when you pressed.** Only a pad pressed **while paused**
+gates. Pressed while playing, it is a normal hot cue: the deck jumps and keeps
+playing, and releasing it does nothing. Whether a press gates is decided at
+the press, so pausing during a hold does not turn it into one.
+
 An **empty** pad does not return. Pressing one sets a cue at the play head
 instead of recalling one, so there is nowhere to return to. See
 [hot cues](hot-cues.md).
@@ -86,7 +91,11 @@ In order:
 
 Give it time on the first play of a track: around 25 seconds for an
 eight-minute track on the setup this was measured on. The track plays normally
-while it waits.
+while it waits. With the STEMS row open, the bar under the caption shows where
+the job is. **PREPARING** standing still is normal: the server is writing the
+parts and reports no count for that step, and how long it takes depends on the
+server. A **!** on the row means the job failed; load another track, then this one
+again, to retry.
 
 ## A groove circuit pad is not lit
 


### PR DESCRIPTION
- README: the STEMS row and the theme strip side by side under the intro, and the cues line says a pad gates only when pressed while paused.
- troubleshooting: a pad pressed while playing is a normal hot cue; what the stems progress bar shows, why PREPARING stands still, and how to retry after a !.
- stems: the job starts at the load, playing or paused; the progress bar's steps; a stick-cached track only shows LOADING. Also the sentence that lost its first word.