### PR TITLE
docs: README screenshots, gate cue needs a paused deck, the stems progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ A set of modifications for the CDJ-3000, installed as a firmware update. They
 run alongside the deck's own application rather than replacing it, and come off
 from the front panel.
 
+<p align="center">
+  <img src="https://cdj3k-mods.com/img/stems-row-unity.png" width="49%" alt="The STEMS row: drums, harmonics and vocals on three faders over the play screen">
+  <img src="https://cdj3k-mods.com/img/theme-comb.png" width="49%" alt="The play screen in six of the themes, one vertical strip each">
+</p>
+
 Features:
 
 - **Cues** — gate cues (hold to play, release to return), smart cues (last hot cue is cue), and

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ from the front panel.
 
 Features:
 
-- **Cues** — gate cues (hold to play, release to return), smart cues (last hot cue is cue), and
-  preview hot cue to set a hot cue with the preview.
+- **Cues** — gate cues (press a pad while paused: hold to play, release to
+  return), smart cues (last hot cue is cue), and preview hot cue to set a hot
+  cue with the preview.
 - **Stems** — drums, harmonics and vocals on three toggles and three faders.
   Separation runs on a computer on your network via
   [stemd](https://github.com/nsaintot/stemd), not on the deck. Groove circuit

--- a/docs/stems.md
+++ b/docs/stems.md
@@ -28,11 +28,11 @@ In [MOD SETTINGS](mod-settings.md):
 ## What happens when you load a track
 
 When you load a track, the deck uploads it to the server, which processes it and
-returns the separated parts. For reference, on an M1 Pro with a Balanced setup,
-an eight-minute track typically took **about 25 seconds** to process.
-track plays normally throughout, and the faders become live when the parts
-arrive.
+returns the separated parts. This starts at a track load. For reference,
+on an M1 Pro with a Balanced setup, an eight-minute track typically took **about 25 seconds** to process.
 
+The track plays normally throughout, and the faders become live when the parts
+arrive.
 - **The second deck is free.** Two decks loading the same track cost one
   separation, the second attaches to the job already running.
 - **A track you have played before is quicker.** The separation is cached, see
@@ -101,6 +101,8 @@ The row sits under the waveform: three controls, one per part (**DRUMS**,
 of the row.
 
 ![The STEMS row open with all three at full.](img/stems-row-unity.png)
+
+While stems are loading, a progress bar replaces the faders, showing steps like **UPLOADING**, **SEPARATING**, **PREPARING**, **DOWNLOADING**, and **LOADING**. If stems are already on the stick, only **LOADING** appears.
 
 | | |
 | --- | --- |


### PR DESCRIPTION
- README: the STEMS row and the theme strip side by side under the intro, and the cues line says a pad gates only when pressed while paused.
- troubleshooting: a pad pressed while playing is a normal hot cue; what the stems progress bar shows, why PREPARING stands still, and how to retry after a !.
- stems: the job starts at the load, playing or paused; the progress bar's steps; a stick-cached track only shows LOADING. Also the sentence that lost its first word.

Replaces #16, which GitHub closed when its branch was renamed.